### PR TITLE
Add PsbDecompile

### DIFF
--- a/FreeMote.PsBuild/FreeMote.PsBuild.csproj
+++ b/FreeMote.PsBuild/FreeMote.PsBuild.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FreeMote.PsBuild</RootNamespace>
     <AssemblyName>FreeMote.PsBuild</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -45,6 +49,21 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PsbCompiler.cs" />
     <Compile Include="PsbDecompiler.cs" />
+    <Compile Include="PsbHelper.cs" />
+    <Compile Include="PsbTypeConverter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FreeMote.Psb\FreeMote.Psb.csproj">
+      <Project>{c0b2c2ff-d8f4-497e-8312-c2af1bb6e7f7}</Project>
+      <Name>FreeMote.Psb</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FreeMote\FreeMote.csproj">
+      <Project>{d43ca425-6476-4ae3-a3d8-bbcac0f0383c}</Project>
+      <Name>FreeMote</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FreeMote.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.PsBuild/Properties/AssemblyInfo.cs
@@ -21,8 +21,9 @@ using System.Runtime.InteropServices;
 
 // 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
 [assembly: Guid("717a63de-e599-4134-92ab-40a17c326da3")]
+[assembly: InternalsVisibleTo("FreeMote.Tests")]
 
-// 程序集的版本信息由下列四个值组成: 
+// 程序集的版本信息由下列四个值组成:
 //
 //      主版本
 //      次版本

--- a/FreeMote.PsBuild/PsbCompiler.cs
+++ b/FreeMote.PsBuild/PsbCompiler.cs
@@ -1,15 +1,34 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FreeMote.Psb;
+using Newtonsoft.Json;
 
 namespace FreeMote.PsBuild
 {
     /// <summary>
     /// Compile PSB File
     /// </summary>
-    class PsbCompiler
+    public class PsbCompiler
     {
+        /// <summary>
+        /// Compile to file
+        /// </summary>
+        /// <param name="inputPath"></param>
+        /// <param name="outputPath"></param>
+        public static void CompileToFile(string inputPath, string outputPath, ushort version = 3)
+        {
+            PSB psb = new PSB(version);
+            psb.Objects = JsonConvert.DeserializeObject<PsbDictionary>(File.ReadAllText(inputPath));
+        }
+
+        internal static void Parse()
+        { }
+
+        internal void Link()
+        { }
     }
 }

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -26,6 +26,13 @@ namespace FreeMote.PsBuild
             return Decompile(psb);
         }
 
+        public static string Decompile(string path, out List<byte[]> resources)
+        {
+            PSB psb = new PSB(path);
+            resources = new List<byte[]>(psb.Resources.Select(r => r.Data));
+            return Decompile(psb);
+        }
+
         internal static string Decompile(PSB psb)
         {
             return JsonConvert.SerializeObject(psb.Objects, Formatting.Indented, new PsbTypeConverter());

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -26,6 +27,13 @@ namespace FreeMote.PsBuild
             return Decompile(psb);
         }
 
+        /// <summary>
+        /// Decompile Pure PSB as Json
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="resources">resources bytes</param>
+        /// <returns></returns>
+
         public static string Decompile(string path, out List<byte[]> resources)
         {
             PSB psb = new PSB(path);
@@ -36,6 +44,28 @@ namespace FreeMote.PsBuild
         internal static string Decompile(PSB psb)
         {
             return JsonConvert.SerializeObject(psb.Objects, Formatting.Indented, new PsbTypeConverter());
+        }
+
+        /// <summary>
+        /// Decompile to files
+        /// </summary>
+        /// <param name="inputPath"></param>
+        public static void DecompileToFile(string inputPath)
+        {
+            var name = Path.GetFileNameWithoutExtension(inputPath);
+            File.WriteAllText(inputPath + ".json", Decompile(inputPath, out List<byte[]> resources));
+            if (!Directory.Exists(name))
+            {
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Directory.CreateDirectory(Path.Combine(Path.GetDirectoryName(inputPath), name));
+            }
+            List<string> resPaths = new List<string>(resources.Count);
+            for (int i = 0; i < resources.Count; i++)
+            {
+                resPaths.Add(Path.Combine(name, $"{i}.bin"));
+                File.WriteAllBytes(resPaths[i], resources[i]);
+            }
+            File.WriteAllText(inputPath + ".res.json", JsonConvert.SerializeObject(resPaths, Formatting.Indented));
         }
     }
 }

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FreeMote;
+using PSB = FreeMote.Psb.Psb;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace FreeMote.PsBuild
 {
@@ -11,5 +15,20 @@ namespace FreeMote.PsBuild
     /// </summary>
     public class PsbDecompiler
     {
+        /// <summary>
+        /// Decompile Pure PSB as Json
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string Decompile(string path)
+        {
+            PSB psb = new PSB(path);
+            return Decompile(psb);
+        }
+
+        internal static string Decompile(PSB psb)
+        {
+            return JsonConvert.SerializeObject(psb.Objects, Formatting.Indented, new PsbTypeConverter());
+        }
     }
 }

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FreeMote;
-using PSB = FreeMote.Psb.Psb;
+using FreeMote.Psb;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/FreeMote.PsBuild/PsbHelper.cs
+++ b/FreeMote.PsBuild/PsbHelper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FreeMote.PsBuild
+{
+    class PsbHelper
+    {
+        public const string ResourceIdentifier = "#resource#";
+    }
+}

--- a/FreeMote.PsBuild/PsbTypeConverter.cs
+++ b/FreeMote.PsBuild/PsbTypeConverter.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FreeMote.Psb;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FreeMote.PsBuild
+{
+    class PsbTypeConverter : JsonConverter
+    {
+        internal static List<Type> SupportTypes = new List<Type> {
+            typeof(PsbNull),typeof(PsbBool),typeof(PsbNumber),
+            typeof(PsbArray), typeof(PsbString),typeof(PsbResource),
+            typeof(PsbCollection),typeof(PsbDictionary),
+        };
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            switch (value)
+            {
+                case PsbNull nul:
+                    writer.WriteNull();
+                    break;
+                case PsbBool b:
+                    writer.WriteValue(b.Value);
+                    break;
+                case PsbNumber num:
+                    switch (num.NumberType)
+                    {
+                        case PsbNumberType.Int:
+                            writer.WriteValue(num.IntValue);
+                            break;
+                        case PsbNumberType.Float:
+                            writer.WriteValue(num.FloatValue);
+                            break;
+                        case PsbNumberType.Double:
+                            writer.WriteValue(num.DoubleValue);
+                            break;
+                        default:
+                            writer.WriteValue(num.LongValue);
+                            break;
+                    }
+                    break;
+                case PsbString str:
+                    writer.WriteValue(str.Value);
+                    break;
+                case PsbResource res:
+                    //writer.WriteValue(Convert.ToBase64String(res.Data, Base64FormattingOptions.None));
+                    writer.WriteValue($"{PsbHelper.ResourceIdentifier}{res.Index}");
+                    break;
+                case PsbArray array:
+                    writer.WriteValue(array.Value);
+                    break;
+                case PsbCollection collection:
+                    writer.WriteStartArray();
+                    if (collection.Value.Count > 0 && !(collection[0] is PsbCollection) && !(collection[0] is PsbDictionary))
+                    {
+                        writer.Formatting = Formatting.None;
+                    }
+                    foreach (var obj in collection.Value)
+                    {
+                        WriteJson(writer, obj, serializer);
+                    }
+                    writer.WriteEndArray();
+                    writer.Formatting = Formatting.Indented;
+                    break;
+                case PsbDictionary dictionary:
+                    writer.WriteStartObject();
+                    foreach (var obj in dictionary.Value)
+                    {
+                        writer.WritePropertyName(obj.Key);
+                        WriteJson(writer, obj.Value, serializer);
+                    }
+                    writer.WriteEndObject();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject obj = JObject.Load(reader);
+            return ConvertToken(obj);
+        }
+
+        internal IPsbValue ConvertToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Null:
+                    return new PsbNull();
+                case JTokenType.Integer:
+                    return new PsbNumber(token.Value<int>());
+                case JTokenType.Float:
+                    var d = token.Value<double>();
+                    if (d < float.MaxValue && d > float.MinValue)
+                    {
+                        return new PsbNumber(token.Value<float>());
+                    }
+                    return new PsbNumber(d);
+                case JTokenType.Boolean:
+                    return new PsbBool(token.Value<bool>());
+                case JTokenType.String:
+                    string s = token.Value<string>();
+                    if (s.StartsWith(PsbHelper.ResourceIdentifier))
+                    {
+                        return new PsbResource(uint.Parse(s.Replace(PsbHelper.ResourceIdentifier, "")));
+                    }
+                    return new PsbString(s);
+                case JTokenType.Array:
+                    var array = (JArray)token;
+                    var collection = new PsbCollection(array.Count);
+                    foreach (var val in array)
+                    {
+                        collection.Value.Add(ConvertToken(val));
+                    }
+                    return collection;
+                case JTokenType.Object:
+                    var obj = (JObject)token;
+                    var dictionary = new PsbDictionary(obj.Count);
+                    foreach (var val in obj)
+                    {
+                        dictionary.Value.Add(val.Key, ConvertToken(val.Value));
+                    }
+                    return dictionary;
+                default:
+                    throw new FormatException("Unsupported json element");
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.GetInterface("IPsbValue") != null;
+            //return SupportTypes.Contains(objectType);
+        }
+    }
+}

--- a/FreeMote.PsBuild/PsbTypeConverter.cs
+++ b/FreeMote.PsBuild/PsbTypeConverter.cs
@@ -21,7 +21,7 @@ namespace FreeMote.PsBuild
         {
             switch (value)
             {
-                case PsbNull nul:
+                case PsbNull _:
                     writer.WriteNull();
                     break;
                 case PsbBool b:
@@ -35,6 +35,7 @@ namespace FreeMote.PsBuild
                             break;
                         case PsbNumberType.Float:
                             writer.WriteValue(num.FloatValue);
+                            //writer.WriteRawValue(num.FloatValue.ToString("R"));
                             break;
                         case PsbNumberType.Double:
                             writer.WriteValue(num.DoubleValue);
@@ -97,10 +98,15 @@ namespace FreeMote.PsBuild
                     return new PsbNumber(token.Value<int>());
                 case JTokenType.Float:
                     var d = token.Value<double>();
-                    if (d < float.MaxValue && d > float.MinValue)
+                    var f = token.Value<float>();
+                    if (Math.Abs(f - d) < double.Epsilon) //float
                     {
                         return new PsbNumber(token.Value<float>());
                     }
+                    //if (d < float.MaxValue && d > float.MinValue)
+                    //{
+                    //    return new PsbNumber(token.Value<float>());
+                    //}
                     return new PsbNumber(d);
                 case JTokenType.Boolean:
                     return new PsbBool(token.Value<bool>());

--- a/FreeMote.PsBuild/packages.config
+++ b/FreeMote.PsBuild/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+</packages>

--- a/FreeMote.Psb/FreeMote.Psb.csproj
+++ b/FreeMote.Psb/FreeMote.Psb.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -42,10 +43,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PixelCompress.cs" />
-    <Compile Include="Psb.cs" />
+    <Compile Include="PSB.cs" />
     <Compile Include="PsbHelper.cs" />
     <Compile Include="PsbTypes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RlCompress.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FreeMote\FreeMote.csproj">

--- a/FreeMote.Psb/PixelCompress.cs
+++ b/FreeMote.Psb/PixelCompress.cs
@@ -11,12 +11,11 @@ namespace FreeMote.Psb
     /// PSB Pixel Compress (for images)
     /// <para>originally by number201724</para>
     /// </summary>
-    public static class PixelCompress
+    internal static class PixelCompress
     {
         public const int LzssLookShift = 7;
         public const int LzssLookAhead = 1 << LzssLookShift;
 
-       
         /// <summary>
         /// Pixel Uncompress
         /// </summary>
@@ -30,23 +29,23 @@ namespace FreeMote.Psb
             //int currentIndex = 0;
             int totalBytes = 0;
             int count;
-            while (actualSize != totalBytes)
+            while (input.Position < input.Length)
             {
                 int current = input.ReadByte();
                 totalBytes++;
-                if ((current & LzssLookAhead) != 0)
+                if ((current & LzssLookAhead) != 0) //Redundant
                 {
                     count = (current ^ LzssLookAhead) + 3;
                     byte[] buffer = new byte[align];
+                    input.Read(buffer, 0, align);
                     for (int i = 0; i < count; i++)
                     {
-                        input.Read(buffer, 0, align);
                         output.Write(buffer, 0, align);
                     }
-                    output.Write(new byte[align], 0, align);
+                    //output.Write(new byte[align], 0, align);
                     totalBytes += align;
                 }
-                else
+                else //not redundant
                 {
                     count = (current + 1) * align;
                     byte[] buffer = new byte[count];

--- a/FreeMote.Psb/PixelCompress.cs
+++ b/FreeMote.Psb/PixelCompress.cs
@@ -163,12 +163,10 @@ namespace FreeMote.Psb
         /// </summary>
         /// <param name="input"></param>
         /// <param name="align"></param>
-        /// <param name="actualSize"></param>
         /// <returns></returns>
-        public static byte[] Compress(Stream input, int align, out int actualSize)
+        public static byte[] Compress(Stream input, int align)
         {
             MemoryStream output = new MemoryStream();
-            int totalSize = 0;
             int blockSize = 0;
             int count;
             byte cmdByte;
@@ -192,10 +190,8 @@ namespace FreeMote.Psb
                     output.WriteByte(cmdByte);
                     output.Write(buffer, 0, buffer.Length);
                 }
-
-                totalSize += blockSize;
+                //totalSize += blockSize;
             }
-            actualSize = totalSize;
             return output.ToArray();
         }
     }

--- a/FreeMote.Psb/Properties/AssemblyInfo.cs
+++ b/FreeMote.Psb/Properties/AssemblyInfo.cs
@@ -21,8 +21,9 @@ using System.Runtime.InteropServices;
 
 // 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
 [assembly: Guid("c0b2c2ff-d8f4-497e-8312-c2af1bb6e7f7")]
+[assembly: InternalsVisibleTo("FreeMote.Tests")]
 
-// 程序集的版本信息由下列四个值组成: 
+// 程序集的版本信息由下列四个值组成:
 //
 //      主版本
 //      次版本

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -73,21 +73,21 @@ namespace FreeMote.Psb
 
             //Pre Load Strings
             br.BaseStream.Seek(Header.OffsetStrings, SeekOrigin.Begin);
-            StringOffsets = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
+            StringOffsets = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
             Strings = new SortedDictionary<uint, PsbString>();
 
             //Load Names
             br.BaseStream.Seek(Header.OffsetNames, SeekOrigin.Begin);
-            Charset = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
-            NamesData = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
-            NameIndexes = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
+            Charset = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
+            NamesData = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
+            NameIndexes = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
             LoadNames();
 
             //Pre Load Resources (Chunks)
             br.BaseStream.Seek(Header.OffsetChunkOffsets, SeekOrigin.Begin);
-            ChunkOffsets = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
+            ChunkOffsets = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
             br.BaseStream.Seek(Header.OffsetChunkLengths, SeekOrigin.Begin);
-            ChunkLengths = new PsbArray(br.ReadByte() - (byte) PsbType.ArrayN1 + 1, br);
+            ChunkLengths = new PsbArray(br.ReadByte() - (byte)PsbType.ArrayN1 + 1, br);
             Resources = new List<PsbResource>(ChunkLengths.Value.Count);
 
             //Load Entries
@@ -135,7 +135,7 @@ namespace FreeMote.Psb
                 }
             }
 
-            Resources.Sort((s1, s2) => (int) s1.Index - (int) s2.Index);
+            Resources.Sort((r1, r2) => (int)r1.Index - (int)r2.Index);
         }
 
         private void LoadNames()
@@ -146,7 +146,6 @@ namespace FreeMote.Psb
                 var list = new List<byte>();
                 var index = NameIndexes[i];
                 var chr = NamesData[(int)index];
-                char temp = (char)0;
                 while (chr != 0)
                 {
                     var code = NamesData[(int)chr];
@@ -327,7 +326,7 @@ namespace FreeMote.Psb
             {
                 Strings.Add(str.Index, str);
             }
-            else if(Strings[str.Index].Value == str.Value)
+            else if (Strings[str.Index].Value == str.Value)
             {
                 //Good
             }

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -4,50 +4,58 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+// ReSharper disable InconsistentNaming
 
 //PSB format is based on psbfile by number201724.
 
 namespace FreeMote.Psb
 {
     /// <summary>
-    /// P S Binary
+    /// Packaged Struct Binary
     /// </summary>
-    public class Psb
+    /// Photo Shop Big
+    /// Pretty SB
+    public class PSB
     {
-        private List<string> NamesCheck;
-
         /// <summary>
         /// Header
         /// </summary>
-        internal PsbHeader Header;
+        internal PsbHeader Header { get; set; }
         internal PsbArray Charset;
         internal PsbArray NamesData;
         internal PsbArray NameIndexes;
         /// <summary>
         /// Names
         /// </summary>
-        public List<string> Names;
+        public List<string> Names { get; set; }
         internal PsbArray StringOffsets;
         /// <summary>
         /// Strings
         /// </summary>
-        public SortedDictionary<uint, PsbString> Strings;
+        public SortedDictionary<uint, PsbString> Strings { get; set; }
         internal PsbArray ChunkOffsets;
         internal PsbArray ChunkLengths;
         /// <summary>
         /// Resource Chunk
         /// </summary>
-        public List<PsbResource> Resources;
+        public List<PsbResource> Resources { get; set; }
 
         /// <summary>
         /// Objects (Entries)
         /// </summary>
-        public PsbDictionary Objects;
+        public PsbDictionary Objects { get; set; }
 
         internal PsbCollection ExpireSuffixList;
         public string Extension { get; internal set; }
 
-        public Psb(string path)
+        //private List<string> NamesCheck;
+
+        public PSB(ushort version = 3)
+        {
+            Header = new PsbHeader() { Version = version };
+        }
+
+        public PSB(string path)
         {
             if (!File.Exists(path))
             {
@@ -59,7 +67,7 @@ namespace FreeMote.Psb
             }
         }
 
-        public Psb(Stream stream)
+        public PSB(Stream stream)
         {
             LoadFromStream(stream);
         }
@@ -105,10 +113,7 @@ namespace FreeMote.Psb
                 {
                     throw new Exception("Wrong offset when parsing objects");
                 }
-                if (Objects == null)
-                {
-                    Objects = obj as PsbDictionary;
-                }
+                Objects = obj as PsbDictionary;
             }
             catch (Exception e)
             {
@@ -166,9 +171,14 @@ namespace FreeMote.Psb
                 //    Strings.Add(index, new PsbString(str, index));
                 //}
             }
-            NamesCheck = new List<string>(Names);
+            //NamesCheck = new List<string>(Names);
         }
 
+        /// <summary>
+        /// Unpack PSB Value
+        /// </summary>
+        /// <param name="br"></param>
+        /// <returns></returns>
         private IPsbValue Unpack(BinaryReader br)
         {
             var typeByte = br.ReadByte();
@@ -258,7 +268,7 @@ namespace FreeMote.Psb
                 var obj = Unpack(br);
                 dictionary.Value.Add(name, obj);
                 //Check
-                NamesCheck.Remove(name);
+                //NamesCheck.Remove(name);
             }
             if (dictionary.Value.ContainsKey("expire_suffix_list"))
             {
@@ -298,6 +308,11 @@ namespace FreeMote.Psb
         /// <param name="br"></param>
         private void LoadResource(PsbResource res, BinaryReader br)
         {
+            //FIXED: Add check for re-used resources
+            if (Resources.Find(r => r.Index == res.Index) != null)
+            {
+                return; //Already loaded!
+            }
             var pos = br.BaseStream.Position;
             var offset = ChunkOffsets[(int)res.Index];
             var length = ChunkLengths[(int)res.Index];
@@ -326,14 +341,15 @@ namespace FreeMote.Psb
             {
                 Strings.Add(str.Index, str);
             }
-            else if (Strings[str.Index].Value == str.Value)
-            {
-                //Good
-            }
-            else
+            else if (Strings[str.Index].Value != str.Value)
             {
                 Debug.WriteLine($"[Conflict] Index:{str.Index} Exists:{Strings[str.Index]} New:{str}");
             }
+        }
+
+        public void Merge()
+        {
+
         }
     }
 }

--- a/FreeMote.Psb/PsbHelper.cs
+++ b/FreeMote.Psb/PsbHelper.cs
@@ -77,6 +77,11 @@ namespace FreeMote.Psb
             return sb.ToString();
         }
 
+        //public static byte[] EnsureLength(this byte[] bytes)
+        //{
+        //    return bytes;
+        //}
+
     }
 
 

--- a/FreeMote.Psb/PsbTypes.cs
+++ b/FreeMote.Psb/PsbTypes.cs
@@ -410,9 +410,6 @@ namespace FreeMote.Psb
 
         public string Value { get; set; }
 
-        //Maybe we shouldn't keep this info here
-        //public uint Index { get; set; } = 0;
-
         /// <summary>
         /// It's based on index...
         /// </summary>
@@ -438,7 +435,7 @@ namespace FreeMote.Psb
 
         public override string ToString()
         {
-            return "\"" + Value + "\"";
+            return "\"" + Value + "\"" + $"(#{Index})";
         }
 
         public static implicit operator string(PsbString s)
@@ -535,7 +532,7 @@ namespace FreeMote.Psb
 
         public override string ToString()
         {
-            return $"Resource[{Data.Length}]";
+            return $"Resource[{Data.Length}](#{Index})";
         }
     }
 

--- a/FreeMote.Psb/PsbTypes.cs
+++ b/FreeMote.Psb/PsbTypes.cs
@@ -85,6 +85,7 @@ namespace FreeMote.Psb
         string ToString();
     }
 
+    [Serializable]
     public class PsbNull : IPsbValue
     {
         public object Value => null;
@@ -97,6 +98,7 @@ namespace FreeMote.Psb
         }
     }
 
+    [Serializable]
     public class PsbBool : IPsbValue
     {
         public PsbBool(bool value = false)
@@ -121,6 +123,7 @@ namespace FreeMote.Psb
         Double
     }
 
+    [Serializable]
     public class PsbNumber : IPsbValue
     {
         internal PsbNumber(PsbType type, BinaryReader br)
@@ -159,7 +162,8 @@ namespace FreeMote.Psb
                     return;
                 case PsbType.Float0:
                     NumberType = PsbNumberType.Float;
-                    Data = br.ReadBytes(1);
+                    //Data = br.ReadBytes(1);
+                    Data = BitConverter.GetBytes(0.0f);
                     return;
                 case PsbType.Float:
                     NumberType = PsbNumberType.Float;
@@ -182,6 +186,36 @@ namespace FreeMote.Psb
         {
             Data = data;
             NumberType = type;
+        }
+
+        /// <summary>
+        /// Int Number
+        /// </summary>
+        /// <param name="val"></param>
+        public PsbNumber(int val)
+        {
+            NumberType = PsbNumberType.Int;
+            IntValue = val;
+        }
+
+        /// <summary>
+        /// Float Number
+        /// </summary>
+        /// <param name="val"></param>
+        public PsbNumber(float val)
+        {
+            NumberType = PsbNumberType.Float;
+            FloatValue = val;
+        }
+
+        /// <summary>
+        /// Double Number
+        /// </summary>
+        /// <param name="val"></param>
+        public PsbNumber(double val)
+        {
+            NumberType = PsbNumberType.Double;
+            DoubleValue = val;
         }
 
         public byte[] Data { get; set; }
@@ -290,6 +324,7 @@ namespace FreeMote.Psb
     /// <summary>
     /// uint[]
     /// </summary>
+    [Serializable]
     public class PsbArray : IPsbValue
     {
         internal PsbArray(int n, BinaryReader br)
@@ -354,48 +389,7 @@ namespace FreeMote.Psb
         }
     }
 
-    public class PsbArray<T> : IPsbValue where T : IPsbValue
-    {
-        public PsbArray()
-        {
-            Value = new List<T>();
-        }
-        public List<T> Value { get; }
-
-        public PsbType Type
-        {
-            get
-            {
-                switch (Value.Count.GetSize())
-                {
-                    case 1:
-                        return PsbType.ArrayN1;
-                    case 2:
-                        return PsbType.ArrayN2;
-                    case 3:
-                        return PsbType.ArrayN3;
-                    case 4:
-                        return PsbType.ArrayN4;
-                    case 5:
-                        return PsbType.ArrayN5;
-                    case 6:
-                        return PsbType.ArrayN6;
-                    case 7:
-                        return PsbType.ArrayN7;
-                    case 8:
-                        return PsbType.ArrayN8;
-                    default:
-                        throw new ArgumentOutOfRangeException("Not a valid array");
-                }
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"Array<{typeof(T).ToString().Replace("Psb", "")}>[{Value.Count}]";
-        }
-    }
-
+    [Serializable]
     public class PsbString : IPsbValue, IPsbIndexed
     {
         internal PsbString(int n, BinaryReader br)
@@ -456,6 +450,7 @@ namespace FreeMote.Psb
     /// <summary>
     /// psb_objects_t
     /// </summary>
+    [Serializable]
     public class PsbDictionary : IPsbValue
     {
         public PsbDictionary(int capacity)
@@ -477,6 +472,7 @@ namespace FreeMote.Psb
         }
     }
 
+    [Serializable]
     public class PsbCollection : IPsbValue
     {
         public PsbCollection(int capacity)
@@ -499,6 +495,7 @@ namespace FreeMote.Psb
         }
     }
 
+    [Serializable]
     public class PsbResource : IPsbValue, IPsbIndexed
     {
         internal PsbResource(int n, BinaryReader br)

--- a/FreeMote.Psb/RlCompress.cs
+++ b/FreeMote.Psb/RlCompress.cs
@@ -16,10 +16,17 @@ namespace FreeMote.Psb
             Bmp,
             Png,
         }
-
-        public static byte[] Compress()
+        private static byte[] Compress(Stream stream, int align = 4)
         {
-            return null;
+            return PixelCompress.Compress(stream, align, out _);
+        }
+
+        private static byte[] Compress(byte[] data, int align = 4)
+        {
+            using (var stream = new MemoryStream(data))
+            {
+                return Compress(stream, align);
+            }
         }
 
         public static void ConvertToImageFile(byte[] data, string path, int height, int width, int align = 4, PsbImageFormat format = PsbImageFormat.Bmp)

--- a/FreeMote.Psb/RlCompress.cs
+++ b/FreeMote.Psb/RlCompress.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace FreeMote.Psb
+{
+    public class RlCompress
+    {
+        public enum PsbImageFormat
+        {
+            Bmp,
+            Png,
+        }
+
+        public static byte[] Compress()
+        {
+            return null;
+        }
+
+        public static void ConvertToImageFile(byte[] data, string path, int height, int width, int align = 4, PsbImageFormat format = PsbImageFormat.Bmp)
+        {
+            byte[] bytes;
+            try
+            {
+                bytes = Uncompress(data, height, width, align);
+            }
+            catch (Exception e)
+            {
+                throw new BadImageFormatException("data incorrect", e);
+            }
+            Bitmap bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            BitmapData bmpData = bmp.LockBits(new Rectangle(0, 0, width, height),
+                ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+
+            //// 获取图像参数
+            int stride = bmpData.Stride;  // 扫描线的宽度
+            int offset = stride - width;  // 显示宽度与扫描线宽度的间隙
+            IntPtr iptr = bmpData.Scan0;  // 获取bmpData的内存起始位置
+            int scanBytes = stride * height;   // 用stride宽度，表示这是内存区域的大小
+
+            if (scanBytes >= bytes.Length)
+            {
+                System.Runtime.InteropServices.Marshal.Copy(bytes, 0, iptr, bytes.Length);
+                bmp.UnlockBits(bmpData);  // 解锁内存区域
+                switch (format)
+                {
+                    case PsbImageFormat.Bmp:
+                        bmp.Save(path, ImageFormat.Bmp);
+                        break;
+                    case PsbImageFormat.Png:
+                        bmp.Save(path, ImageFormat.Png);
+                        break;
+                }
+
+                return;
+            }
+            throw new BadImageFormatException("data may not corresponding");
+        }
+
+        public static void ConvertToWinFormatFile()
+        { }
+
+        private static byte[] Uncompress(Stream stream, int height, int width, int align = 4)
+        {
+            var realLength = height * width * align;
+            return PixelCompress.Uncompress(stream, realLength, align);
+        }
+
+        private static byte[] Uncompress(byte[] data, int height, int width, int align = 4)
+        {
+            using (var stream = new MemoryStream(data))
+            {
+                return Uncompress(stream, height, width, align);
+            }
+        }
+    }
+}

--- a/FreeMote.Purify/readme.md
+++ b/FreeMote.Purify/readme.md
@@ -3,7 +3,7 @@
 A tool lib to *infer* the key of an Emote PSB file. It doesn't need any other file(e.g. DLL), and can do inference without brute force. It can get the key very fast and is universal for most Emote PSB files. It's NOT based on already known keys.
 
 # Feature
-* support Emote PSB v2-v4 (only works with *Emote* PSB, not for normal PSB)
+* Support Emote PSB v2-v4 (only works with *Emote* PSB, not for normal PSB)
 * Very fast because it's all from inference rather than brute force
 * Can handle both header & body(string) encryption
 

--- a/FreeMote.Tests/FreeMote.Tests.csproj
+++ b/FreeMote.Tests/FreeMote.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FreeMote.Tests</RootNamespace>
     <AssemblyName>FreeMote.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,9 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.1.14\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FreeMote.Tests/FreeMote.Tests.csproj
+++ b/FreeMote.Tests/FreeMote.Tests.csproj
@@ -50,10 +50,15 @@
   <ItemGroup>
     <Compile Include="FreeMoteTest.cs" />
     <Compile Include="PsbTest.cs" />
+    <Compile Include="PsBuildTest.cs" />
     <Compile Include="PurifyTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\FreeMote.PsBuild\FreeMote.PsBuild.csproj">
+      <Project>{717a63de-e599-4134-92ab-40a17c326da3}</Project>
+      <Name>FreeMote.PsBuild</Name>
+    </ProjectReference>
     <ProjectReference Include="..\FreeMote.Psb\FreeMote.Psb.csproj">
       <Project>{c0b2c2ff-d8f4-497e-8312-c2af1bb6e7f7}</Project>
       <Name>FreeMote.Psb</Name>

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -68,7 +68,12 @@ namespace FreeMote.Tests
             var target = paths[0];
             var json = PsbDecompiler.Decompile(target);
             File.WriteAllText(target + ".json", json);
-            Console.WriteLine(json);
+        }
+
+        [TestMethod]
+        public void TestCompile()
+        {
+
         }
     }
 }

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.IO;
+using FreeMote.PsBuild;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FreeMote.Tests
+{
+    /// <summary>
+    /// PsBuildTest 的摘要说明
+    /// </summary>
+    [TestClass]
+    public class PsBuildTest
+    {
+        public PsBuildTest()
+        {
+            //
+            //TODO:  在此处添加构造函数逻辑
+            //
+        }
+
+        private TestContext testContextInstance;
+
+        /// <summary>
+        ///获取或设置测试上下文，该上下文提供
+        ///有关当前测试运行及其功能的信息。
+        ///</summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        #region 附加测试特性
+        //
+        // 编写测试时，可以使用以下附加特性:
+        //
+        // 在运行类中的第一个测试之前使用 ClassInitialize 运行代码
+        // [ClassInitialize()]
+        // public static void MyClassInitialize(TestContext testContext) { }
+        //
+        // 在类中的所有测试都已运行之后使用 ClassCleanup 运行代码
+        // [ClassCleanup()]
+        // public static void MyClassCleanup() { }
+        //
+        // 在运行每个测试之前，使用 TestInitialize 来运行代码
+        // [TestInitialize()]
+        // public void MyTestInitialize() { }
+        //
+        // 在每个测试运行完之后，使用 TestCleanup 来运行代码
+        // [TestCleanup()]
+        // public void MyTestCleanup() { }
+        //
+        #endregion
+
+        [TestMethod]
+        public void TestDecompile()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            var paths = Directory.GetFiles(resPath, "*pure.psb");
+            var target = paths[0];
+            var json = PsbDecompiler.Decompile(target);
+            File.WriteAllText(target + ".json", json);
+            Console.WriteLine(json);
+        }
+    }
+}

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using FreeMote.PsBuild;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace FreeMote.Tests
 {
@@ -74,6 +75,28 @@ namespace FreeMote.Tests
         public void TestCompile()
         {
 
+        }
+
+        [TestMethod]
+        public void TestJsonNumbers()
+        {
+            List<float> floats = new List<float> { -0.00000001f, 1/3f, -0.000027f, 19.200079f, (float)Math.PI, float.MinValue};
+            string json = JsonConvert.SerializeObject(floats);
+            Console.WriteLine(json);
+            var result = JsonConvert.DeserializeObject<List<float>>(json);
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.AreEqual(floats[i], result[i]);
+            }
+
+            List<double> doubles  = new List<double> { double.MinValue, double.MaxValue, 123456789.0, -0.00000001, 0.03, 0.4 };
+            json = JsonConvert.SerializeObject(doubles);
+            Console.WriteLine(json);
+            var result2 = JsonConvert.DeserializeObject<List<double>>(json);
+            for (int i = 0; i < result2.Count; i++)
+            {
+                Assert.AreEqual(doubles[i], result2[i]);
+            }
         }
     }
 }

--- a/FreeMote.Tests/PsbTest.cs
+++ b/FreeMote.Tests/PsbTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FreeMote.Psb;
-using PSB = FreeMote.Psb.Psb;
 
 
 namespace FreeMote.Tests
@@ -30,19 +29,13 @@ namespace FreeMote.Tests
         ///</summary>
         public TestContext TestContext
         {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
+            get => testContextInstance;
+            set => testContextInstance = value;
         }
 
         #region 附加测试特性
         //
-        // 编写测试时，可以使用以下附加特性: 
+        // 编写测试时，可以使用以下附加特性:
         //
         // 在运行类中的第一个测试之前使用 ClassInitialize 运行代码
         // [ClassInitialize()]
@@ -82,6 +75,29 @@ namespace FreeMote.Tests
             {
                 PSB psb = new PSB(fs);
             }
+        }
+
+        [TestMethod]
+        public void TestPsbLoadKrkr()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            var paths = Directory.GetFiles(resPath, "澄怜a_裸.psb-pure.psb");
+            using (FileStream fs = new FileStream(paths[0], FileMode.Open))
+            {
+                PSB psb = new PSB(fs);
+            }
+        }
+
+        [TestMethod]
+        public void TestRlUncompress()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+
+            var path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "84.bin"); //輪郭00
+            RlCompress.ConvertToImageFile(File.ReadAllBytes(path), path + ".png", 570, 426);
+            path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "89.bin"); //胸00
+            RlCompress.ConvertToImageFile(File.ReadAllBytes(path), path + ".png", 395, 411);
+
         }
     }
 }

--- a/FreeMote.Tests/packages.config
+++ b/FreeMote.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.1.14" targetFramework="net46" />
   <package id="MSTest.TestFramework" version="1.1.14" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net47" />
 </packages>

--- a/FreeMote.Tools.EmotePsbConverter/App.config
+++ b/FreeMote.Tools.EmotePsbConverter/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/FreeMote.Tools.EmotePsbConverter/Program.cs
+++ b/FreeMote.Tools.EmotePsbConverter/Program.cs
@@ -13,7 +13,7 @@ namespace FreeMote.Tools.EmotePsbConverter
         private static uint? NewKey = null;
         static void Main(string[] args)
         {
-            Console.WriteLine("FreeMote E-mote PSB Converter");
+            Console.WriteLine("FreeMote PSB Converter");
             Console.WriteLine("by Ulysses, wdwxy12345@gmail.com");
             Console.WriteLine();
             if (args.Length >= 3)

--- a/FreeMote.Tools.PsBuild/App.config
+++ b/FreeMote.Tools.PsBuild/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/FreeMote.Tools.PsBuild/FreeMote.Tools.PsBuild.csproj
+++ b/FreeMote.Tools.PsBuild/FreeMote.Tools.PsBuild.csproj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{44270712-4ACB-447D-835E-9982BD515DBB}</ProjectGuid>
+    <ProjectGuid>{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>FreeMote.Tools.EmotePsbConverter</RootNamespace>
-    <AssemblyName>EmoteConv</AssemblyName>
+    <RootNamespace>FreeMote.Tools.PsBuild</RootNamespace>
+    <AssemblyName>PsBuild</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,12 +47,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\FreeMote\FreeMote.csproj">
-      <Project>{d43ca425-6476-4ae3-a3d8-bbcac0f0383c}</Project>
-      <Name>FreeMote</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FreeMote.Tools.PsBuild/Program.cs
+++ b/FreeMote.Tools.PsBuild/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FreeMote.Tools.PsBuild
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 // 有关程序集的一般信息由以下
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
-[assembly: AssemblyTitle("FreeMote.Tools.EmotePsbConverter")]
-[assembly: AssemblyDescription("Convert Emote PSB file using FreeMote.")]
+[assembly: AssemblyTitle("FreeMote.Tools.PsBuild")]
+[assembly: AssemblyDescription("Compile Emote project to PSB.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
-[assembly: Guid("44270712-4acb-447d-835e-9982bd515dbb")]
+[assembly: Guid("d877dbdb-41d7-4c6f-9a46-957cecdaefa8")]
 
 // 程序集的版本信息由下列四个值组成: 
 //

--- a/FreeMote.Tools.PsbDecompile/App.config
+++ b/FreeMote.Tools.PsbDecompile/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/FreeMote.Tools.PsbDecompile/App.config
+++ b/FreeMote.Tools.PsbDecompile/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
 </configuration>

--- a/FreeMote.Tools.PsbDecompile/FreeMote.Tools.PsbDecompile.csproj
+++ b/FreeMote.Tools.PsbDecompile/FreeMote.Tools.PsbDecompile.csproj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{44270712-4ACB-447D-835E-9982BD515DBB}</ProjectGuid>
+    <ProjectGuid>{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>FreeMote.Tools.EmotePsbConverter</RootNamespace>
-    <AssemblyName>EmoteConv</AssemblyName>
+    <RootNamespace>FreeMote.Tools.PsbDecompile</RootNamespace>
+    <AssemblyName>PsbDecompile</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FreeMote\FreeMote.csproj">
-      <Project>{d43ca425-6476-4ae3-a3d8-bbcac0f0383c}</Project>
-      <Name>FreeMote</Name>
+    <ProjectReference Include="..\FreeMote.PsBuild\FreeMote.PsBuild.csproj">
+      <Project>{717a63de-e599-4134-92ab-40a17c326da3}</Project>
+      <Name>FreeMote.PsBuild</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/FreeMote.Tools.PsbDecompile/FreeMote.Tools.PsbDecompile.csproj
+++ b/FreeMote.Tools.PsbDecompile/FreeMote.Tools.PsbDecompile.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FreeMote.Tools.PsbDecompile</RootNamespace>
     <AssemblyName>PsbDecompile</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/FreeMote.Tools.PsbDecompile/Program.cs
+++ b/FreeMote.Tools.PsbDecompile/Program.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FreeMote.PsBuild;
 
 namespace FreeMote.Tools.PsbDecompile
 {
@@ -10,6 +12,45 @@ namespace FreeMote.Tools.PsbDecompile
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("FreeMote PSB Decompiler");
+            Console.WriteLine("by Ulysses, wdwxy12345@gmail.com");
+            Console.WriteLine();
+
+            foreach (var s in args)
+            {
+                if (File.Exists(s))
+                {
+                    Decompile(s);
+                }
+                else if(Directory.Exists(s))
+                {
+                    foreach (var file in Directory.EnumerateFiles(s, "*.psb"))
+                    {
+                        Decompile(file);
+                    }
+                    foreach (var file in Directory.EnumerateFiles(s, "*.mmo"))
+                    {
+                        Decompile(file);
+                    }
+                }
+            }
+
+            Console.WriteLine("Done.");
+        }
+
+        static void Decompile(string path)
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            Console.WriteLine($"Decompiling: {name}");
+            try
+            {
+                PsbDecompiler.DecompileToFile(path);
+
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
         }
     }
 }

--- a/FreeMote.Tools.PsbDecompile/Program.cs
+++ b/FreeMote.Tools.PsbDecompile/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FreeMote.Tools.PsbDecompile
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 // 有关程序集的一般信息由以下
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
-[assembly: AssemblyTitle("FreeMote.Tools.EmotePsbConverter")]
-[assembly: AssemblyDescription("Convert Emote PSB file using FreeMote.")]
+[assembly: AssemblyTitle("FreeMote.Tools.PsbDecompile")]
+[assembly: AssemblyDescription("Emote PSB Decompiler.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
-[assembly: Guid("44270712-4acb-447d-835e-9982bd515dbb")]
+[assembly: Guid("943fe440-32bb-4caf-a1da-5f38de7f9b92")]
 
 // 程序集的版本信息由下列四个值组成: 
 //

--- a/FreeMote.sln
+++ b/FreeMote.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.Purify", "FreeMote.Purify\FreeMote.Purify.csproj", "{859B3831-C3A5-4FF9-B1FE-BD5D3F6A6452}"
 EndProject
@@ -14,6 +14,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.PsBuild", "FreeMote.PsBuild\FreeMote.PsBuild.csproj", "{717A63DE-E599-4134-92AB-40A17C326DA3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.Tools.EmotePsbConverter", "FreeMote.Tools.EmotePsbConverter\FreeMote.Tools.EmotePsbConverter.csproj", "{44270712-4ACB-447D-835E-9982BD515DBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.Tools.PsbDecompile", "FreeMote.Tools.PsbDecompile\FreeMote.Tools.PsbDecompile.csproj", "{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.Tools.PsBuild", "FreeMote.Tools.PsBuild\FreeMote.Tools.PsBuild.csproj", "{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{44270712-4ACB-447D-835E-9982BD515DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44270712-4ACB-447D-835E-9982BD515DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44270712-4ACB-447D-835E-9982BD515DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{943FE440-32BB-4CAF-A1DA-5F38DE7F9B92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D877DBDB-41D7-4C6F-9A46-957CECDAEFA8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FreeMote/Properties/AssemblyInfo.cs
+++ b/FreeMote/Properties/AssemblyInfo.cs
@@ -21,11 +21,12 @@ using System.Runtime.InteropServices;
 
 // 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
 [assembly: Guid("d43ca425-6476-4ae3-a3d8-bbcac0f0383c")]
+[assembly: InternalsVisibleTo("FreeMote.PsBuild")]
 [assembly: InternalsVisibleTo("FreeMote.Purify")]
 [assembly: InternalsVisibleTo("FreeMote.Psb")]
 [assembly: InternalsVisibleTo("FreeMote.Tests")]
 
-// 程序集的版本信息由下列四个值组成: 
+// 程序集的版本信息由下列四个值组成:
 //
 //      主版本
 //      次版本

--- a/FreeMote/PsbHeader.cs
+++ b/FreeMote/PsbHeader.cs
@@ -111,10 +111,6 @@ namespace FreeMote
                     header.OffsetResourceOffsets = br.ReadUInt32();
                 }
             }
-            //else
-            //{
-            //    throw new NotSupportedException("Header seems encrypted.");
-            //}
             return header;
         }
 
@@ -198,14 +194,23 @@ namespace FreeMote
             return 44u;
         }
 
-        public void SwitchVersion(ushort version = 3)
+        public void SwitchVersion(ushort version = 3, bool offsetFields = false)
         {
             if (version != 2 && version != 3 && version != 4)
             {
                 throw new ArgumentOutOfRangeException("Unsupported version");
             }
+
             Version = version;
             long headerLen = GetHeaderLength(version);
+            if (!offsetFields)
+            {
+                HeaderLength = (uint) headerLen;
+                OffsetNames = HeaderLength;
+                UpdateChecksum();
+                return;
+            }
+
             long offset = headerLen - HeaderLength;
 
             if (offset != 0)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Managed Emote tool libs.
 ### FreeMote
 Basic functions. Decrypt or encrypt Emote PSB files.
 ### FreeMote [(SDK)](https://github.com/Project-AZUSA/FreeMote-SDK)
-Special API libs for Emote engine, which takes unencrypted PSB files as input.
+Special API libs for Emote engine, which takes _pure_ (unencrypted) PSB files as input.
 ### FreeMote.Psb
 Parse Emote PSB format.
 ### FreeMote.PsBuild (In Dev)
@@ -37,6 +37,7 @@ FreeMote is temporarily licensed under LGPL. Members from Project AZUSA can use 
 ## Thanks
 
 * @9chu for reverse engineering help.
-* @number201724 for psb format.
+* @number201724 for PSB format.
 * @nalsas (awatm) for Emote Editor help.
+* @WcLyic (牧濑红莉栖) for some PSB samples and Emote Edior help.
 * Singyuen Yip for `Adler32` code.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Emote <-> Live2D Conversion
 ## Tools
 ### EmoteConv (FreeMote.Tools.EmotePsbConverter)
 Convert Emote PSB files. A managed version of `emote_conv`(by number201724).
+### PsbDecompile (FreeMote.Tools.PsbDecompile)
+Decompile PSB files. A managed version of `decompiler`(by number201724).
+### PsBuild (FreeMote.Tools.PsBuild) (In Dev)
+Compile Emote description json to PSB.
 ### EmoteMeasurer (FreeMote.Tools.EmoteMeasurer) (In Dev)
 Measure specific positions of models to help Emote PSB version migration.
 


### PR DESCRIPTION
You can now decompile a pure PSB using `PsbDecompile`.

## Warning:
The format of psb json is going to be changed in next versions. You may have to decompile it again for other usages at that time.

The psb jsons are NOT compatible with `psbtools` by number201724. Our tools may also support psbtools format jsons.