### PR TITLE
FreeMote 1.1

### DIFF
--- a/FreeMote.PsBuild/Converters/CommonWinConverter.cs
+++ b/FreeMote.PsBuild/Converters/CommonWinConverter.cs
@@ -22,8 +22,8 @@ namespace FreeMote.PsBuild.Converters
         /// If true, it is an EmsWinConverter
         /// </summary>
         public bool EmsAsCommon { get; set; } = false;
-        public IList<PsbSpec> FromSpec { get; } = new List<PsbSpec> {PsbSpec.win, PsbSpec.common};
-        public IList<PsbSpec> ToSpec { get; } = new List<PsbSpec> {PsbSpec.krkr, PsbSpec.win};
+        public IList<PsbSpec> FromSpec { get; } = new List<PsbSpec> {PsbSpec.win, PsbSpec.common, PsbSpec.ems};
+        public IList<PsbSpec> ToSpec { get; } = new List<PsbSpec> {PsbSpec.common, PsbSpec.win, PsbSpec.ems};
         public void Convert(PSB psb)
         {
             if (!FromSpec.Contains(psb.Platform))

--- a/FreeMote.PsBuild/Converters/CommonWinConverter.cs
+++ b/FreeMote.PsBuild/Converters/CommonWinConverter.cs
@@ -5,7 +5,7 @@ using FreeMote.Psb;
 namespace FreeMote.PsBuild.Converters
 {
     /// <summary>
-    /// Common-Win Converter
+    /// Common/Ems-Win Converter
     /// </summary>
     class CommonWinConverter : ISpecConverter
     {
@@ -18,6 +18,10 @@ namespace FreeMote.PsBuild.Converters
         /// </summary>
         public PsbPixelFormat TargetPixelFormat { get; set; }
         public bool UseRL { get; set; } = false;
+        /// <summary>
+        /// If true, it is an EmsWinConverter
+        /// </summary>
+        public bool EmsAsCommon { get; set; } = false;
         public IList<PsbSpec> FromSpec { get; } = new List<PsbSpec> {PsbSpec.win, PsbSpec.common};
         public IList<PsbSpec> ToSpec { get; } = new List<PsbSpec> {PsbSpec.krkr, PsbSpec.win};
         public void Convert(PSB psb)
@@ -26,8 +30,10 @@ namespace FreeMote.PsBuild.Converters
             {
                 throw new FormatException("Can not convert Spec for this PSB");
             }
-            var toSpec = psb.Platform == PsbSpec.win ? PsbSpec.common : PsbSpec.win;
-            var toPixelFormat = toSpec == PsbSpec.common ? PsbPixelFormat.CommonRGBA8 : PsbPixelFormat.WinRGBA8;
+
+            var asSpec = EmsAsCommon ? PsbSpec.ems : PsbSpec.common;
+            var toSpec = psb.Platform == PsbSpec.win ? asSpec : PsbSpec.win;
+            var toPixelFormat = toSpec == asSpec ? PsbPixelFormat.CommonRGBA8 : PsbPixelFormat.WinRGBA8;
             var resList = psb.CollectResources(false);
             foreach (var resMd in resList)
             {

--- a/FreeMote.PsBuild/Converters/Krkr2CommonConverter.cs
+++ b/FreeMote.PsBuild/Converters/Krkr2CommonConverter.cs
@@ -24,8 +24,8 @@ namespace FreeMote.PsBuild.Converters
 
         public PsbPixelFormat TargetPixelFormat { get; set; }
         public bool UseRL { get; set; } = false;
-        public IList<PsbSpec> FromSpec { get; } = new List<PsbSpec> { PsbSpec.win, PsbSpec.krkr };
-        public IList<PsbSpec> ToSpec { get; } = new List<PsbSpec> { PsbSpec.krkr };
+        public IList<PsbSpec> FromSpec { get; } = new List<PsbSpec> { PsbSpec.krkr };
+        public IList<PsbSpec> ToSpec { get; } = new List<PsbSpec> { PsbSpec.win, PsbSpec.common };
         public bool ToWin { get; set; }
 
         public int? TextureSideLength { get; set; } = null;

--- a/FreeMote.PsBuild/FreeMote.PsBuild.csproj
+++ b/FreeMote.PsBuild/FreeMote.PsBuild.csproj
@@ -57,6 +57,7 @@
     <Compile Include="PsbCompiler.cs" />
     <Compile Include="PsbDecompiler.cs" />
     <Compile Include="PsbResCollector.cs" />
+    <Compile Include="PsbResourceJson.cs" />
     <Compile Include="PsbTypeConverter.cs" />
     <Compile Include="ResourceMetadata.cs" />
     <Compile Include="Converters\CommonWinConverter.cs" />

--- a/FreeMote.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.PsBuild/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
 [assembly: AssemblyTitle("FreeMote.PsBuild")]
-[assembly: AssemblyDescription("Managed Emote PSB Compiler & Decompiler")]
+[assembly: AssemblyDescription("Managed PSB Compiler & Decompiler")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Ulysses  2017")]
+[assembly: AssemblyCopyright("Copyright © Ulysses 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.PsBuild/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.*")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/FreeMote.PsBuild/PsbCompiler.cs
+++ b/FreeMote.PsBuild/PsbCompiler.cs
@@ -179,7 +179,7 @@ namespace FreeMote.PsBuild
                     continue;
                 }
                 var fullPath = Path.Combine(baseDir ?? "", resPath.Replace('/', '\\'));
-                byte[] data = LoadImageBytes(fullPath, psb.Platform.CompressType(), resMd.PixelFormat);
+                byte[] data = LoadImageBytes(fullPath, resMd.Compress/*psb.Platform.CompressType()*/, resMd.PixelFormat);
                 resMd.Resource.Data = data;
             }
         }

--- a/FreeMote.PsBuild/PsbCompiler.cs
+++ b/FreeMote.PsBuild/PsbCompiler.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using FreeMote.Psb;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace FreeMote.PsBuild
 {
@@ -22,7 +23,7 @@ namespace FreeMote.PsBuild
         /// <param name="version">PSB version</param>
         /// <param name="cryptKey">CryptKey, if you need to use it outside FreeMote</param>
         /// <param name="platform">PSB Platform</param>
-        public static void CompileToFile(string inputPath, string outputPath, string inputResPath = null, ushort version = 3, uint? cryptKey = null, PsbSpec? platform = null)
+        public static void CompileToFile(string inputPath, string outputPath, string inputResPath = null, ushort? version = null, uint? cryptKey = null, PsbSpec? platform = null)
         {
             if (string.IsNullOrEmpty(inputPath))
             {
@@ -61,15 +62,48 @@ namespace FreeMote.PsBuild
         /// <param name="cryptKey">CryptKey, if you need to use it outside FreeMote</param>
         /// <param name="spec">PSB Platform</param>
         /// <returns></returns>
-        public static byte[] Compile(string inputJson, string inputResJson, string baseDir = null, ushort version = 3, uint? cryptKey = null,
+        public static byte[] Compile(string inputJson, string inputResJson, string baseDir = null, ushort? version = null, uint? cryptKey = null,
             PsbSpec? spec = null)
         {
             //Parse
-            PSB psb = Parse(inputJson, version);
+            PSB psb = Parse(inputJson, version ?? 3);
             //Link
             if (!string.IsNullOrWhiteSpace(inputResJson))
             {
-                psb.Link(inputResJson, baseDir);
+                if (inputResJson.Trim().StartsWith("{")) //resx.json
+                {
+                    PsbResourceJson resx = JsonConvert.DeserializeObject<PsbResourceJson>(inputResJson);
+                    if (resx.PsbType != null)
+                    {
+                        psb.Type = resx.PsbType.Value;
+                    }
+                    if (resx.PsbVersion != null && version == null)
+                    {
+                        psb.Header.Version = resx.PsbVersion.Value;
+                    }
+                    if (resx.Platform != null && spec == null)
+                    {
+                        psb.SwitchSpec(resx.Platform.Value, resx.Platform.Value.DefaultPixelFormat());
+                    }
+                    if (resx.CryptKey != null & cryptKey == null)
+                    {
+                        cryptKey = resx.CryptKey;
+                    }
+
+                    if (resx.ExternalTextures)
+                    {
+                        Console.WriteLine("[INFO] External Texture mode ON, no resource will be compiled.");
+                    }
+                    else
+                    {
+                        psb.Link(resx, baseDir);
+                    }
+                }
+                else
+                {
+                    List<string> resources = JsonConvert.DeserializeObject<List<string>>(inputResJson);
+                    psb.Link(resources, baseDir);
+                }
             }
             //Build
             psb.Merge();
@@ -90,7 +124,7 @@ namespace FreeMote.PsBuild
         /// <param name="inputResPath">Resource Json file</param>
         /// <param name="version">PSB version</param>
         /// <returns></returns>
-        public static PSB LoadPsbFromJsonFile(string inputPath, string inputResPath = null, ushort version = 3)
+        public static PSB LoadPsbFromJsonFile(string inputPath, string inputResPath = null, ushort? version = null)
         {
             if (string.IsNullOrEmpty(inputPath))
             {
@@ -106,20 +140,52 @@ namespace FreeMote.PsBuild
                 }
             }
 
-            string resJson = null;
+            string inputResJson = null;
             string baseDir = Path.GetDirectoryName(inputPath);
             if (File.Exists(inputResPath))
             {
-                resJson = File.ReadAllText(inputResPath);
+                inputResJson = File.ReadAllText(inputResPath);
                 baseDir = Path.GetDirectoryName(inputPath);
             }
 
             //Parse
-            PSB psb = Parse(File.ReadAllText(inputPath), version);
+            PSB psb = Parse(File.ReadAllText(inputPath), version ?? 3);
             //Link
-            if (!string.IsNullOrWhiteSpace(resJson))
+            if (!string.IsNullOrWhiteSpace(inputResJson))
             {
-                psb.Link(resJson, baseDir);
+                if (inputResJson.Trim().StartsWith("{")) //resx.json
+                {
+                    PsbResourceJson resx = JsonConvert.DeserializeObject<PsbResourceJson>(inputResJson);
+                    if (resx.PsbType != null)
+                    {
+                        psb.Type = resx.PsbType.Value;
+                    }
+                    if (resx.PsbVersion != null && version == null)
+                    {
+                        psb.Header.Version = resx.PsbVersion.Value;
+                    }
+                    if (resx.Platform != null)
+                    {
+                        psb.SwitchSpec(resx.Platform.Value, resx.Platform.Value.DefaultPixelFormat());
+                    }
+                    if (resx.ExternalTextures)
+                    {
+                        Console.WriteLine("[INFO] External Texture mode ON, no resource will be compiled.");
+                    }
+                    else
+                    {
+                        psb.Link(resx, baseDir);
+                    }
+                }
+                else
+                {
+                    List<string> resources = JsonConvert.DeserializeObject<List<string>>(inputResJson);
+                    psb.Link(resources, baseDir);
+                }
+            }
+            if (version != null)
+            {
+                psb.Header.Version = version.Value;
             }
             psb.Merge();
             return psb;
@@ -148,7 +214,7 @@ namespace FreeMote.PsBuild
                             data = RL.CompressImageFile(path, pixelFormat);
                             break;
                         case PsbCompressType.Tlg:
-                            //TODO: TLG encode
+                        //TODO: TLG encode
                         default:
                             data = RL.GetPixelBytesFromImageFile(path, pixelFormat);
                             break;
@@ -172,11 +238,10 @@ namespace FreeMote.PsBuild
         /// Link
         /// </summary>
         /// <param name="psb"></param>
-        /// <param name="resJson"></param>
+        /// <param name="resPaths">resource paths</param>
         /// <param name="baseDir"></param>
-        internal static void Link(this PSB psb, string resJson, string baseDir = null)
+        internal static void Link(this PSB psb, List<string> resPaths, string baseDir = null)
         {
-            List<string> resPaths = JsonConvert.DeserializeObject<List<string>>(resJson);
             var resList = psb.CollectResources();
             foreach (var resPath in resPaths)
             {
@@ -191,6 +256,35 @@ namespace FreeMote.PsBuild
                     continue;
                 }
                 var fullPath = Path.Combine(baseDir ?? "", resPath.Replace('/', '\\'));
+                byte[] data = LoadImageBytes(fullPath, resMd.Compress/*psb.Platform.CompressType()*/, resMd.PixelFormat);
+                resMd.Resource.Data = data;
+            }
+        }
+
+        /// <summary>
+        /// Link
+        /// </summary>
+        /// <param name="psb"></param>
+        /// <param name="resx">advanced resource json(resx.jon)</param>
+        /// <param name="baseDir"></param>
+        internal static void Link(this PSB psb, PsbResourceJson resx, string baseDir)
+        {
+            var resList = psb.CollectResources();
+            foreach (var resxResource in resx.Resources)
+            {
+                var resMd = uint.TryParse(resxResource.Key, out uint rid)
+                    ? resList.FirstOrDefault(r => r.Index == rid)
+                    : resList.FirstOrDefault(r =>
+                        resxResource.Key == $"{r.Part}{PsbResCollector.ResourceNameDelimiter}{r.Name}");
+                if (resMd == null)
+                {
+                    Console.WriteLine($"[WARN]{resxResource.Key} is not used.");
+                    continue;
+                }
+
+                var fullPath = Path.IsPathRooted(resxResource.Value)
+                    ? resxResource.Value
+                    : Path.Combine(baseDir ?? "", resxResource.Value.Replace('/', '\\'));
                 byte[] data = LoadImageBytes(fullPath, resMd.Compress/*psb.Platform.CompressType()*/, resMd.PixelFormat);
                 resMd.Resource.Data = data;
             }

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -91,7 +91,15 @@ namespace FreeMote.PsBuild
                 //var relativePath = spec == PsbSpec.krkr
                 //    ? $"{name}/{resource.Part}-{resource.Name}"
                 //    : $"{name}/{resource.Part}";
-                var relativePath = $"{resource.Part}{PsbResCollector.ResourceNameDelimiter}{resource.Name}";
+                string relativePath;
+                if (string.IsNullOrWhiteSpace(resource.Name) || string.IsNullOrWhiteSpace(resource.Part))
+                {
+                    relativePath = resource.Index.ToString();
+                }
+                else
+                {
+                    relativePath = $"{resource.Part}{PsbResCollector.ResourceNameDelimiter}{resource.Name}";
+                }
                 switch (imageOption)
                 {
                     case PsbImageOption.Extract:

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using FreeMote.Psb;
 using Newtonsoft.Json;
 
@@ -113,6 +112,12 @@ namespace FreeMote.PsBuild
                                     RL.UncompressToImageFile(resource.Data, Path.Combine(dirPath, relativePath),
                                         resource.Height, resource.Width, PsbImageFormat.Png, resource.PixelFormat);
                                 }
+                                else if (resource.Compress == PsbCompressType.Tlg)
+                                {
+                                    //TODO: TLG decode
+                                    relativePath = Path.ChangeExtension(relativePath, ".tlg");
+                                    File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
+                                }
                                 else
                                 {
                                     RL.ConvertToImageFile(resource.Data, Path.Combine(dirPath, relativePath),
@@ -126,6 +131,12 @@ namespace FreeMote.PsBuild
                                     RL.UncompressToImageFile(resource.Data, Path.Combine(dirPath, relativePath),
                                         resource.Height, resource.Width, PsbImageFormat.Bmp, resource.PixelFormat);
                                 }
+                                else if (resource.Compress == PsbCompressType.Tlg)
+                                {
+                                    //TODO: TLG decode
+                                    relativePath = Path.ChangeExtension(relativePath, ".tlg");
+                                    File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
+                                }
                                 else
                                 {
                                     RL.ConvertToImageFile(resource.Data, Path.Combine(dirPath, relativePath),
@@ -138,6 +149,11 @@ namespace FreeMote.PsBuild
                         if (resources[i].Compress == PsbCompressType.RL)
                         {
                             relativePath += ".rl";
+                            File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
+                        }
+                        else if (resource.Compress == PsbCompressType.Tlg)
+                        {
+                            relativePath += ".tlg";
                             File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
                         }
                         else

--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing.Imaging;
 using System.IO;
 using FreeMote.Psb;
 using Newtonsoft.Json;
@@ -114,7 +115,13 @@ namespace FreeMote.PsBuild
                                 }
                                 else if (resource.Compress == PsbCompressType.Tlg)
                                 {
-                                    //TODO: TLG decode
+                                    TlgImageConverter converter = new TlgImageConverter();
+                                    using (var ms = new MemoryStream(resource.Data))
+                                    {
+                                        BinaryReader br = new BinaryReader(ms);
+                                        converter.Read(br).Save(Path.Combine(dirPath, relativePath), ImageFormat.Png);
+                                    }
+                                    //WARN: tlg is kept and recorded in resource json for compile 
                                     relativePath = Path.ChangeExtension(relativePath, ".tlg");
                                     File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
                                 }
@@ -133,7 +140,13 @@ namespace FreeMote.PsBuild
                                 }
                                 else if (resource.Compress == PsbCompressType.Tlg)
                                 {
-                                    //TODO: TLG decode
+                                    TlgImageConverter converter = new TlgImageConverter();
+                                    using (var ms = new MemoryStream(resource.Data))
+                                    {
+                                        BinaryReader br = new BinaryReader(ms);
+                                        converter.Read(br).Save(Path.Combine(dirPath, relativePath), ImageFormat.Bmp);
+                                    }
+                                    //WARN: tlg is kept and recorded in resource json for compile 
                                     relativePath = Path.ChangeExtension(relativePath, ".tlg");
                                     File.WriteAllBytes(Path.Combine(dirPath, relativePath), resource.Data);
                                 }

--- a/FreeMote.PsBuild/PsbResCollector.cs
+++ b/FreeMote.PsBuild/PsbResCollector.cs
@@ -188,6 +188,7 @@ namespace FreeMote.PsBuild
             switch (spec)
             {
                 case PsbSpec.krkr:
+                case PsbSpec.ems:
                     return PsbCompressType.RL;
                 case PsbSpec.common:
                 case PsbSpec.win:
@@ -315,7 +316,23 @@ namespace FreeMote.PsBuild
             {
                 return;
             }
+
+            //Alternative //TODO: Alternative table?
+            bool isAlternative = false;
+            var realTargetSpec = PsbSpec.common;
+
             var original = psb.Platform;
+            if (original == PsbSpec.ems)
+            {
+                original = PsbSpec.common;
+            }
+
+            if (targetSpec == PsbSpec.ems)
+            {
+                isAlternative = true;
+                realTargetSpec = targetSpec;
+                targetSpec = PsbSpec.common;
+            }
 
             if (targetSpec == PsbSpec.krkr) //krkr can not select pixel format
             {
@@ -339,7 +356,7 @@ namespace FreeMote.PsBuild
                 }
             }
 
-            if (targetSpec == PsbSpec.win)
+            else if (targetSpec == PsbSpec.win)
             {
                 switch (original)
                 {
@@ -357,7 +374,7 @@ namespace FreeMote.PsBuild
                 }
             }
 
-            if (targetSpec == PsbSpec.common)
+            else if (targetSpec == PsbSpec.common || targetSpec == PsbSpec.ems)
             {
                 switch (original)
                 {
@@ -369,10 +386,24 @@ namespace FreeMote.PsBuild
                         CommonWinConverter commonWin = new CommonWinConverter();
                         commonWin.Convert(psb);
                         break;
+                    case PsbSpec.common:
+                    case PsbSpec.ems:
+                        psb.Platform = targetSpec;
+                        break;
                     default:
                         psb.Platform = targetSpec;
                         break;
                 }
+            }
+
+            else
+            {
+                psb.Platform = targetSpec;
+            }
+
+            if (isAlternative)
+            {
+                psb.Platform = realTargetSpec;
             }
         }
     }

--- a/FreeMote.PsBuild/PsbResCollector.cs
+++ b/FreeMote.PsBuild/PsbResCollector.cs
@@ -389,14 +389,14 @@ namespace FreeMote.PsBuild
                 {
                     case PsbSpec.win:
                         {
-                            Common2KrkrConverter converter = new Common2KrkrConverter();
-                            converter.Convert(psb);
+                            Common2KrkrConverter winKrkr = new Common2KrkrConverter();
+                            winKrkr.Convert(psb);
                             break;
                         }
                     case PsbSpec.common:
                         {
-                            Common2KrkrConverter converter = new Common2KrkrConverter();
-                            converter.Convert(psb);
+                            Common2KrkrConverter commonKrkr = new Common2KrkrConverter();
+                            commonKrkr.Convert(psb);
                             break;
                         }
                     default:
@@ -410,12 +410,12 @@ namespace FreeMote.PsBuild
                 switch (original)
                 {
                     case PsbSpec.krkr:
-                        Krkr2CommonConverter krkr2Common = new Krkr2CommonConverter(true);
-                        krkr2Common.Convert(psb);
+                        Krkr2CommonConverter krkr2Win = new Krkr2CommonConverter(true);
+                        krkr2Win.Convert(psb);
                         break;
                     case PsbSpec.common:
-                        CommonWinConverter commonWin = new CommonWinConverter();
-                        commonWin.Convert(psb);
+                        CommonWinConverter winCommon = new CommonWinConverter();
+                        winCommon.Convert(psb);
                         break;
                     default:
                         psb.Platform = targetSpec;
@@ -428,8 +428,8 @@ namespace FreeMote.PsBuild
                 switch (original)
                 {
                     case PsbSpec.krkr:
-                        Krkr2CommonConverter converter = new Krkr2CommonConverter();
-                        converter.Convert(psb);
+                        Krkr2CommonConverter krkr2Common = new Krkr2CommonConverter();
+                        krkr2Common.Convert(psb);
                         break;
                     case PsbSpec.win:
                         CommonWinConverter commonWin = new CommonWinConverter();

--- a/FreeMote.PsBuild/PsbResCollector.cs
+++ b/FreeMote.PsBuild/PsbResCollector.cs
@@ -12,7 +12,8 @@ namespace FreeMote.PsBuild
     {
         public const string ResourceIdentifier = "#resource#";
         public const string ResourceKey = "pixel";
-        public const string SourceKey = "source";
+        public const string MotionSourceKey = "source";
+        public const string PimgSourceKey = "layers";
         /// <summary>
         /// delimiter for output texture filename
         /// </summary>
@@ -28,36 +29,84 @@ namespace FreeMote.PsBuild
         {
             List<ResourceMetadata> resourceList = psb.Resources == null ? new List<ResourceMetadata>() : new List<ResourceMetadata>(psb.Resources.Count);
 
-            FindResources(resourceList, psb.Objects[SourceKey], deDuplication);
-            //Set Spec
-            resourceList.ForEach(r => r.Spec = psb.Platform);
+            switch (psb.Type)
+            {
+                case PsbType.Pimg:
+                case PsbType.Scn:
+                    resourceList.AddRange(psb.Objects.Where(k => k.Value is PsbResource).Select(k =>
+                        new ResourceMetadata()
+                        {
+                            Name = k.Key,
+                            Resource = k.Value as PsbResource,
+                            Compress = k.Key.EndsWith(".tlg", true, null) ? PsbCompressType.Tlg : PsbCompressType.ByName
+                        }));
+                    FindPimgResources(resourceList, psb.Objects[PimgSourceKey], deDuplication);
+                    break;
+                case PsbType.Motion:
+                default:
+                    FindMotionResources(resourceList, psb.Objects[MotionSourceKey], deDuplication);
+                    //Set Spec
+                    resourceList.ForEach(r => r.Spec = psb.Platform);
+                    break;
+            }
             resourceList.Sort((md1, md2) => (int)(md1.Index - md2.Index));
 
             return resourceList;
         }
 
-        private static void FindResources(List<ResourceMetadata> list, IPsbValue obj, bool deDuplication = true)
+        private static void FindPimgResources(List<ResourceMetadata> list, IPsbValue obj, bool deDuplication = true)
+        {
+            if (obj is PsbCollection c)
+            {
+                foreach (var o in c)
+                {
+                    if (!(o is PsbDictionary dic)) continue;
+                    if (dic["layer_id"] is PsbString layerId)
+                    {
+                        var res = list.FirstOrDefault(k => k.Name.StartsWith(layerId.Value, true, null));
+                        if (res == null)
+                        {
+                            continue;
+                        }
+                        if (uint.TryParse(layerId.Value, out var id))
+                        {
+                            res.Index = id;
+                        }
+                        if (dic["width"] is PsbNumber nw)
+                        {
+                            res.Width = deDuplication ? Math.Max((int)nw, res.Width) : (int)nw;
+                        }
+                        if (dic["height"] is PsbNumber nh)
+                        {
+                            res.Height = deDuplication ? Math.Max((int)nh, res.Height) : (int)nh;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void FindMotionResources(List<ResourceMetadata> list, IPsbValue obj, bool deDuplication = true)
         {
             switch (obj)
             {
                 case PsbCollection c:
-                    c.ForEach(o => FindResources(list, o, deDuplication));
+                    c.ForEach(o => FindMotionResources(list, o, deDuplication));
                     break;
                 case PsbDictionary d:
                     if (d[ResourceKey] is PsbResource r)
                     {
                         if (!deDuplication)
                         {
-                            list.Add(GenerateResourceMetadata(d, r));
+                            list.Add(GenerateMotionResMetadata(d, r));
                         }
                         else if (r.Index == null || list.FirstOrDefault(md => md.Index == r.Index.Value) == null)
                         {
-                            list.Add(GenerateResourceMetadata(d, r));
+                            list.Add(GenerateMotionResMetadata(d, r));
                         }
                     }
                     foreach (var o in d.Values)
                     {
-                        FindResources(list, o, deDuplication);
+                        FindMotionResources(list, o, deDuplication);
                     }
                     break;
             }
@@ -69,7 +118,7 @@ namespace FreeMote.PsBuild
         /// <param name="d">PsbObject which contains "pixel"</param>
         /// <param name="r">Resource</param>
         /// <returns></returns>
-        internal static ResourceMetadata GenerateResourceMetadata(PsbDictionary d, PsbResource r = null)
+        internal static ResourceMetadata GenerateMotionResMetadata(PsbDictionary d, PsbResource r = null)
         {
             if (r == null)
             {
@@ -339,17 +388,17 @@ namespace FreeMote.PsBuild
                 switch (original)
                 {
                     case PsbSpec.win:
-                    {
-                        Common2KrkrConverter converter = new Common2KrkrConverter();
-                        converter.Convert(psb);
-                        break;
-                    }
+                        {
+                            Common2KrkrConverter converter = new Common2KrkrConverter();
+                            converter.Convert(psb);
+                            break;
+                        }
                     case PsbSpec.common:
-                    {
-                        Common2KrkrConverter converter = new Common2KrkrConverter();
-                        converter.Convert(psb);
-                        break;
-                    }
+                        {
+                            Common2KrkrConverter converter = new Common2KrkrConverter();
+                            converter.Convert(psb);
+                            break;
+                        }
                     default:
                         psb.Platform = targetSpec;
                         break;

--- a/FreeMote.PsBuild/PsbResourceJson.cs
+++ b/FreeMote.PsBuild/PsbResourceJson.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace FreeMote.PsBuild
+{
+    /// <summary>
+    /// Advanced resource json (.resx.json)
+    /// </summary>
+    /// JsonConvert.SerializeObject(MyObject, new Newtonsoft.Json.Converters.StringEnumConverter());
+    [Serializable]
+    class PsbResourceJson
+    {
+        /// <summary>
+        /// PSB version
+        /// </summary>
+        public ushort? PsbVersion { get; set; } = 3;
+
+        /// <summary>
+        /// PSB Type
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PsbType? PsbType { get; set; } = null;
+
+        /// <summary>
+        /// PSB Spec (only for Emote)
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PsbSpec? Platform { get; set; } = null;
+
+        /// <summary>
+        /// Key
+        /// </summary>
+        public uint? CryptKey { get; set; } = null;
+
+        /// <summary>
+        /// Whether to use external textures
+        /// </summary>
+        public bool ExternalTextures { get; set; } = false;
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        public Dictionary<string, string> Resources { get; set; }
+    }
+}

--- a/FreeMote.PsBuild/ResourceMetadata.cs
+++ b/FreeMote.PsBuild/ResourceMetadata.cs
@@ -23,6 +23,14 @@ namespace FreeMote.PsBuild
         /// Raw Bitmap
         /// </summary>
         Bmp,
+        /// <summary>
+        /// KRKR TLG
+        /// </summary>
+        Tlg,
+        /// <summary>
+        /// By extension
+        /// </summary>
+        ByName,
     }
 
     /// <summary>
@@ -98,7 +106,8 @@ namespace FreeMote.PsBuild
             }
         }
 
-        private string DebuggerString => $"{Part}/{Name}({Width}*{Height}){(Compress == PsbCompressType.RL ? "[RL]" : "")}";
+        private string DebuggerString =>
+            $"{(string.IsNullOrWhiteSpace(Part) ? "" : Part + "/")}{Name}({Width}*{Height}){(Compress == PsbCompressType.RL ? "[RL]" : "")}";
 
         /// <summary>
         /// Convert Resource to Image

--- a/FreeMote.PsBuild/ResourceMetadata.cs
+++ b/FreeMote.PsBuild/ResourceMetadata.cs
@@ -16,7 +16,7 @@ namespace FreeMote.PsBuild
         /// </summary>
         None,
         /// <summary>
-        /// RL
+        /// RLE
         /// </summary>
         RL,
         /// <summary>

--- a/FreeMote.PsBuild/ResourceMetadata.cs
+++ b/FreeMote.PsBuild/ResourceMetadata.cs
@@ -100,6 +100,8 @@ namespace FreeMote.PsBuild
                         return PsbPixelFormat.DXT5;
                     case "RGBA8":
                         return Spec == PsbSpec.common ? PsbPixelFormat.CommonRGBA8 : PsbPixelFormat.WinRGBA8;
+                    case "RGBA4444":
+                        return PsbPixelFormat.RGBA4444;
                         default:
                         return PsbPixelFormat.None;
                 }

--- a/FreeMote.PsBuild/Textures/TextureSpliter.cs
+++ b/FreeMote.PsBuild/Textures/TextureSpliter.cs
@@ -23,7 +23,7 @@ namespace FreeMote.PsBuild.Textures
             //var mipmap = (PsbDictionary)texture["mipMap"]; //TODO: Mipmap?
             Dictionary<string, Bitmap> textures = new Dictionary<string, Bitmap>(icon.Count);
 
-            var md = PsbResCollector.GenerateResourceMetadata(texture, (PsbResource)texture["pixel"]);
+            var md = PsbResCollector.GenerateMotionResMetadata(texture, (PsbResource)texture["pixel"]);
             md.Spec = spec; //Important
             Bitmap bmp = md.ToImage();
             foreach (var iconPair in icon)
@@ -84,7 +84,7 @@ namespace FreeMote.PsBuild.Textures
 
                 //var mipmap = (PsbDictionary)texture["mipMap"]; //TODO: Mipmap?
 
-                var md = PsbResCollector.GenerateResourceMetadata(texture, (PsbResource)texture["pixel"]);
+                var md = PsbResCollector.GenerateMotionResMetadata(texture, (PsbResource)texture["pixel"]);
                 md.Spec = psb.Platform; //Important
                 Bitmap bmp = md.ToImage();
 

--- a/FreeMote.Psb/Properties/AssemblyInfo.cs
+++ b/FreeMote.Psb/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.*")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/FreeMote.Psb/Properties/AssemblyInfo.cs
+++ b/FreeMote.Psb/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
 [assembly: AssemblyTitle("FreeMote.Psb")]
-[assembly: AssemblyDescription("Emote PSB Parser")]
+[assembly: AssemblyDescription("PSB Parser")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © number201724 & Ulysses  2017")]
+[assembly: AssemblyCopyright("Copyright © number201724 & Ulysses 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -512,6 +512,8 @@ namespace FreeMote.Psb
                         else
                         {
                             //Something is wrong
+                            Strings.Add(s);
+                            s.Index = (uint) Strings.IndexOf(s);
                         }
                         break;
                     case PsbCollection c:

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -29,7 +29,7 @@ namespace FreeMote.Psb
         /// <summary>
         /// Names
         /// </summary>
-        public List<string> Names { get; set; }
+        public List<string> Names { get; internal set; }
 
         private PsbArray StringOffsets;
         /// <summary>
@@ -42,7 +42,7 @@ namespace FreeMote.Psb
         /// <summary>
         /// Resource Chunk
         /// </summary>
-        public List<PsbResource> Resources { get; set; }
+        public List<PsbResource> Resources { get; internal set; }
 
         /// <summary>
         /// Objects (Entries)
@@ -107,6 +107,11 @@ namespace FreeMote.Psb
         public PsbType InferType()
         {
             if (Objects.Any(k=> k.Key.Contains(".tlg")))
+            {
+                return PsbType.Pimg;
+            }
+
+            if (Objects.ContainsKey("layers") && Objects.ContainsKey("height") && Objects.ContainsKey("width"))
             {
                 return PsbType.Pimg;
             }

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -23,22 +23,22 @@ namespace FreeMote.Psb
         /// </summary>
         internal PsbHeader Header { get; set; }
 
-        internal PsbArray Charset;
-        internal PsbArray NamesData;
-        internal PsbArray NameIndexes;
+        private PsbArray Charset;
+        private PsbArray NamesData;
+        private PsbArray NameIndexes;
         /// <summary>
         /// Names
         /// </summary>
         public List<string> Names { get; set; }
 
-        internal PsbArray StringOffsets;
+        private PsbArray StringOffsets;
         /// <summary>
         /// Strings
         /// </summary>
         public List<PsbString> Strings { get; set; }
 
-        internal PsbArray ChunkOffsets;
-        internal PsbArray ChunkLengths;
+        private PsbArray ChunkOffsets;
+        private PsbArray ChunkLengths;
         /// <summary>
         /// Resource Chunk
         /// </summary>

--- a/FreeMote.Psb/Psb.cs
+++ b/FreeMote.Psb/Psb.cs
@@ -763,7 +763,7 @@ namespace FreeMote.Psb
             for (int i = 0; i < Resources.Count; i++)
             {
                 File.WriteAllBytes(
-                    Path.Combine(path, Resources[i].Index == null ? $"{i}.bin" : $"{Resources[i].Index}.bin"),
+                    Path.Combine(path, Resources[i].Index == null ? $"#{i}.bin" : $"{Resources[i].Index}.bin"),
                     Resources[i].Data);
             }
         }

--- a/FreeMote.Psb/PsbHelper.cs
+++ b/FreeMote.Psb/PsbHelper.cs
@@ -167,6 +167,7 @@ namespace FreeMote.Psb
             switch (spec)
             {
                 case PsbSpec.common:
+                case PsbSpec.ems:
                     return PsbPixelFormat.CommonRGBA8;
                 case PsbSpec.krkr:
                 case PsbSpec.win:

--- a/FreeMote.Psb/PsbHelper.cs
+++ b/FreeMote.Psb/PsbHelper.cs
@@ -179,6 +179,25 @@ namespace FreeMote.Psb
         }
 
         /// <summary>
+        /// Get <see cref="PsbType"/>'s default extension
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string DefaultExtension(this PsbType type)
+        {
+            switch (type)
+            {
+                case PsbType.Pimg:
+                    return "pimg";
+                case PsbType.Scn:
+                    return "scn";
+                case PsbType.Motion:
+                default:
+                    return "psb";
+            }
+        }
+
+        /// <summary>
         /// Get it's Name in <see cref="PsbDictionary"/>
         /// </summary>
         /// <param name="c"></param>

--- a/FreeMote.Psb/PsbTypes.cs
+++ b/FreeMote.Psb/PsbTypes.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace FreeMote.Psb
 {
-    public enum PsbType : byte
+    public enum PsbObjType : byte
     {
 
         None = 0x0,
@@ -123,7 +123,7 @@ namespace FreeMote.Psb
     public interface IPsbIndexed
     {
         uint? Index { get; set; }
-        PsbType Type { get; }
+        PsbObjType Type { get; }
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ namespace FreeMote.Psb
     /// </summary>
     public interface IPsbValue
     {
-        PsbType Type { get; }
+        PsbObjType Type { get; }
         string ToString();
     }
 
@@ -145,7 +145,7 @@ namespace FreeMote.Psb
 
         public object Value => null;
 
-        public PsbType Type { get; } = PsbType.Null;
+        public PsbObjType Type { get; } = PsbObjType.Null;
 
         public override string ToString()
         {
@@ -173,7 +173,7 @@ namespace FreeMote.Psb
 
         public bool Value { get; set; } = false;
 
-        public PsbType Type => Value ? PsbType.True : PsbType.False;
+        public PsbObjType Type => Value ? PsbObjType.True : PsbObjType.False;
 
         public override string ToString()
         {
@@ -196,50 +196,50 @@ namespace FreeMote.Psb
     [Serializable]
     public class PsbNumber : IPsbValue, IPsbWrite
     {
-        internal PsbNumber(PsbType type, BinaryReader br)
+        internal PsbNumber(PsbObjType objType, BinaryReader br)
         {
             Data = new byte[8];
             NumberType = PsbNumberType.Int;
 
-            switch (type)
+            switch (objType)
             {
-                case PsbType.NumberN0:
+                case PsbObjType.NumberN0:
                     IntValue = 0;
                     return;
-                case PsbType.NumberN1:
+                case PsbObjType.NumberN1:
                     Data = br.ReadBytes(1).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN2:
+                case PsbObjType.NumberN2:
                     Data = br.ReadBytes(2).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN3:
+                case PsbObjType.NumberN3:
                     Data = br.ReadBytes(3).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN4:
+                case PsbObjType.NumberN4:
                     Data = br.ReadBytes(4).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN5:
+                case PsbObjType.NumberN5:
                     Data = br.ReadBytes(5).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN6:
+                case PsbObjType.NumberN6:
                     Data = br.ReadBytes(6).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN7:
+                case PsbObjType.NumberN7:
                     Data = br.ReadBytes(7).UnzipNumberBytes();
                     return;
-                case PsbType.NumberN8:
+                case PsbObjType.NumberN8:
                     Data = br.ReadBytes(8).UnzipNumberBytes();
                     return;
-                case PsbType.Float0:
+                case PsbObjType.Float0:
                     NumberType = PsbNumberType.Float;
                     //Data = br.ReadBytes(1);
                     Data = BitConverter.GetBytes(0.0f);
                     return;
-                case PsbType.Float:
+                case PsbObjType.Float:
                     NumberType = PsbNumberType.Float;
                     Data = br.ReadBytes(4);
                     return;
-                case PsbType.Double:
+                case PsbObjType.Double:
                     NumberType = PsbNumberType.Double;
                     Data = br.ReadBytes(8);
                     return;
@@ -344,9 +344,9 @@ namespace FreeMote.Psb
 
         public bool IsNumber32()
         {
-            return Type == PsbType.NumberN0 || Type == PsbType.NumberN1 ||
-                   Type == PsbType.NumberN2 || Type == PsbType.NumberN3 ||
-                   Type == PsbType.NumberN4;
+            return Type == PsbObjType.NumberN0 || Type == PsbObjType.NumberN1 ||
+                   Type == PsbObjType.NumberN2 || Type == PsbObjType.NumberN3 ||
+                   Type == PsbObjType.NumberN4;
         }
 
         public static explicit operator int(PsbNumber p)
@@ -406,7 +406,7 @@ namespace FreeMote.Psb
             return new PsbNumber(n);
         }
 
-        public PsbType Type
+        public PsbObjType Type
         {
             get
             {
@@ -418,23 +418,23 @@ namespace FreeMote.Psb
                             case 1:
                                 if (IntValue == 0)
                                 {
-                                    return PsbType.NumberN0;
+                                    return PsbObjType.NumberN0;
                                 }
-                                return PsbType.NumberN1;
+                                return PsbObjType.NumberN1;
                             case 2:
-                                return PsbType.NumberN2;
+                                return PsbObjType.NumberN2;
                             case 3:
-                                return PsbType.NumberN3;
+                                return PsbObjType.NumberN3;
                             case 4:
-                                return PsbType.NumberN4;
+                                return PsbObjType.NumberN4;
                             case 5:
-                                return PsbType.NumberN5;
+                                return PsbObjType.NumberN5;
                             case 6:
-                                return PsbType.NumberN6;
+                                return PsbObjType.NumberN6;
                             case 7:
-                                return PsbType.NumberN7;
+                                return PsbObjType.NumberN7;
                             case 8:
-                                return PsbType.NumberN8;
+                                return PsbObjType.NumberN8;
                             default:
                                 throw new ArgumentOutOfRangeException("Not a valid Integer");
                         }
@@ -442,11 +442,11 @@ namespace FreeMote.Psb
                         //TODO: Float0 or not
                         if (Math.Abs(FloatValue) < float.Epsilon) //should we just use 0?
                         {
-                            return PsbType.Float0;
+                            return PsbObjType.Float0;
                         }
-                        return PsbType.Float;
+                        return PsbObjType.Float;
                     case PsbNumberType.Double:
-                        return PsbType.Double;
+                        return PsbObjType.Double;
                     default:
                         throw new ArgumentOutOfRangeException("Unknown number type");
                 }
@@ -464,13 +464,13 @@ namespace FreeMote.Psb
             switch (NumberType)
             {
                 case PsbNumberType.Int:
-                    if (Type != PsbType.NumberN0)
+                    if (Type != PsbObjType.NumberN0)
                     {
                         bw.Write(IntValue.ZipNumberBytes());
                     }
                     break;
                 case PsbNumberType.Float:
-                    if (Type != PsbType.Float0)
+                    if (Type != PsbObjType.Float0)
                     {
                         bw.Write(FloatValue);
                     }
@@ -489,13 +489,13 @@ namespace FreeMote.Psb
             switch (NumberType)
             {
                 case PsbNumberType.Int:
-                    if (Type != PsbType.NumberN0)
+                    if (Type != PsbObjType.NumberN0)
                     {
                         return IntValue.ZipNumberBytes();
                     }
                     return new byte[0];
                 case PsbNumberType.Float:
-                    if (Type != PsbType.Float0)
+                    if (Type != PsbObjType.Float0)
                     {
                         return BitConverter.GetBytes(FloatValue);
                     }
@@ -521,7 +521,7 @@ namespace FreeMote.Psb
             {
                 throw new ArgumentOutOfRangeException("Long array is not supported yet");
             }
-            EntryLength = (byte)(br.ReadByte() - PsbType.NumberN8);
+            EntryLength = (byte)(br.ReadByte() - PsbObjType.NumberN8);
             Value = new List<uint>((int)count);
             for (int i = 0; i < count; i++)
             {
@@ -548,28 +548,28 @@ namespace FreeMote.Psb
         public byte EntryLength { get; private set; } = 4;
         public List<uint> Value { get; }
 
-        public PsbType Type
+        public PsbObjType Type
         {
             get
             {
                 switch (Value.Count.GetSize())
                 {
                     case 1:
-                        return PsbType.ArrayN1;
+                        return PsbObjType.ArrayN1;
                     case 2:
-                        return PsbType.ArrayN2;
+                        return PsbObjType.ArrayN2;
                     case 3:
-                        return PsbType.ArrayN3;
+                        return PsbObjType.ArrayN3;
                     case 4:
-                        return PsbType.ArrayN4;
+                        return PsbObjType.ArrayN4;
                     case 5:
-                        return PsbType.ArrayN5;
+                        return PsbObjType.ArrayN5;
                     case 6:
-                        return PsbType.ArrayN6;
+                        return PsbObjType.ArrayN6;
                     case 7:
-                        return PsbType.ArrayN7;
+                        return PsbObjType.ArrayN7;
                     case 8:
-                        return PsbType.ArrayN8;
+                        return PsbObjType.ArrayN8;
                     default:
                         throw new ArgumentOutOfRangeException("Not a valid array");
                 }
@@ -600,7 +600,7 @@ namespace FreeMote.Psb
         {
             bw.Write((byte)Type); //Type
             bw.Write(Value.Count.ZipNumberBytes(Value.Count.GetSize())); //Count
-            bw.Write((byte)(GetEntryLength() + (byte)PsbType.NumberN8)); //FIXED: EntryLength is added by 0xC
+            bw.Write((byte)(GetEntryLength() + (byte)PsbObjType.NumberN8)); //FIXED: EntryLength is added by 0xC
             foreach (var u in Value)
             {
                 bw.Write(u.ZipNumberBytes(EntryLength));
@@ -633,7 +633,7 @@ namespace FreeMote.Psb
         /// <summary>
         /// It's based on index...
         /// </summary>
-        public PsbType Type
+        public PsbObjType Type
         {
             get
             {
@@ -641,13 +641,13 @@ namespace FreeMote.Psb
                 switch (size)
                 {
                     case 1:
-                        return PsbType.StringN1;
+                        return PsbObjType.StringN1;
                     case 2:
-                        return PsbType.StringN2;
+                        return PsbObjType.StringN2;
                     case 3:
-                        return PsbType.StringN3;
+                        return PsbObjType.StringN3;
                     case 4:
-                        return PsbType.StringN4;
+                        return PsbObjType.StringN4;
                     default:
                         throw new ArgumentOutOfRangeException("size", "Not a valid string");
                 }
@@ -739,7 +739,7 @@ namespace FreeMote.Psb
             set => base[index] = value;
         }
 
-        public PsbType Type { get; } = PsbType.Objects;
+        public PsbObjType Type { get; } = PsbObjType.Objects;
 
         public override string ToString()
         {
@@ -768,7 +768,7 @@ namespace FreeMote.Psb
 
         IPsbValue IPsbCollection.this[string s] => int.TryParse(s, out int i) ? base[i] : null;
 
-        public PsbType Type { get; } = PsbType.Collection;
+        public PsbObjType Type { get; } = PsbObjType.Collection;
 
         public override string ToString()
         {
@@ -796,7 +796,7 @@ namespace FreeMote.Psb
         public uint? Index { get; set; }
         public byte[] Data { get; set; } = new byte[0];
 
-        public PsbType Type
+        public PsbObjType Type
         {
             get
             {
@@ -804,13 +804,13 @@ namespace FreeMote.Psb
                 switch (size)
                 {
                     case 1:
-                        return PsbType.ResourceN1;
+                        return PsbObjType.ResourceN1;
                     case 2:
-                        return PsbType.ResourceN2;
+                        return PsbObjType.ResourceN2;
                     case 3:
-                        return PsbType.ResourceN3;
+                        return PsbObjType.ResourceN3;
                     case 4:
-                        return PsbType.ResourceN4;
+                        return PsbObjType.ResourceN4;
                     default:
                         throw new ArgumentOutOfRangeException("Index", "Not a valid resource");
                 }

--- a/FreeMote.Psb/PsbTypes.cs
+++ b/FreeMote.Psb/PsbTypes.cs
@@ -141,7 +141,7 @@ namespace FreeMote.Psb
         /// <summary>
         /// Use <see cref="Null"/> to avoid duplicated null
         /// </summary>
-        internal PsbNull() { }
+        private PsbNull() { }
 
         public object Value => null;
 

--- a/FreeMote.Tests/FreeMoteTest.cs
+++ b/FreeMote.Tests/FreeMoteTest.cs
@@ -15,9 +15,6 @@ namespace FreeMote.Tests
     {
         public FreeMoteTest()
         {
-            //
-            //TODO:  在此处添加构造函数逻辑
-            //
         }
 
         private TestContext testContextInstance;

--- a/FreeMote.Tests/FreeMoteTest.cs
+++ b/FreeMote.Tests/FreeMoteTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -182,6 +180,21 @@ namespace FreeMote.Tests
                     img.Save($"{tlg}.png", ImageFormat.Png);
                 }
             }
+        }
+
+        [TestMethod]
+        public void TestRGBA4444()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            //var path = Path.Combine(resPath, "emote_test.pure", "tex#000-texture.raw");
+            var path = Path.Combine(resPath, "emote_test.pure", "tex#000-texture.png");
+            var bts = RL.GetPixelBytesFromImageFile(path, PsbPixelFormat.RGBA4444);
+            Assert.IsTrue(
+                bts.SequenceEqual(
+                    File.ReadAllBytes(
+                        Path.Combine(resPath, "emote_test.pure", "tex#000-texture.raw"))));
+                
+            RL.ConvertToImageFile(bts, "rgba4444.png", 2048, 2048, PsbImageFormat.Png, PsbPixelFormat.RGBA4444);
         }
     }
 }

--- a/FreeMote.Tests/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tests/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Ulysses  2017")]
+[assembly: AssemblyCopyright("Copyright © Ulysses 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -58,9 +58,9 @@ namespace FreeMote.Tests
         public void TestDirectCompile()
         {
             var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-            var path = Path.Combine(resPath, "ca01_l_body_1.psz.psb-pure.psb");
+            var path = Path.Combine(resPath, "emote_test2-pure.psb");
             PSB psb = new PSB(path);
-            psb.Header.Version = 2;
+            psb.Header.Version = 3;
             psb.UpdateIndexes();
             File.WriteAllBytes(path + ".build.psb", psb.Build());
         }
@@ -81,6 +81,19 @@ namespace FreeMote.Tests
             //var path = Path.Combine(resPath, "D愛子a_春服-pure.psb.json");
             var path = Path.Combine(resPath, "dx_e-mote3.0ショコラパジャマa-pure.psb.json");
             PsbCompiler.CompileToFile(path, path + ".psbuild.psb", null, 4, null, PsbSpec.win);
+        }
+
+        [TestMethod]
+        public void TestCompileEms()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            //var path = Path.Combine(resPath, "akira_guide-pure.psb.json");
+            var path = Path.Combine(resPath, "emote_test2-pure.psb.json");
+            var psb = PsbCompiler.LoadPsbFromJsonFile(path);
+            psb.Platform = PsbSpec.ems;
+            psb.Merge();
+            File.WriteAllBytes(path + ".build.psb", psb.Build()); 
+            //PsbCompiler.CompileToFile(path, path + ".psbuild.psb", null, 3, null, PsbSpec.ems);
         }
 
         [TestMethod]
@@ -321,6 +334,31 @@ namespace FreeMote.Tests
             File.WriteAllBytes("emote_common2win.psb", psb.Build());
         }
 
+        [TestMethod]
+        public void TestConvertWin2Common()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+
+            var path = Path.Combine(resPath, "ca01_l_body_1.psz.psb-pure.psb");
+            //PSB psb = PsbCompiler.LoadPsbFromJsonFile(path);
+            PSB psb = new PSB(path);
+            psb.SwitchSpec(PsbSpec.common);
+            psb.Merge();
+            File.WriteAllBytes("emote_win2common.psb", psb.Build());
+        }
+
+        [TestMethod]
+        public void TestConvertWin2Ems()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+
+            var path = Path.Combine(resPath, "ca01_s_body_2.psz.psb-pure.psb");
+            //PSB psb = PsbCompiler.LoadPsbFromJsonFile(path);
+            PSB psb = new PSB(path);
+            psb.SwitchSpec(PsbSpec.ems);
+            psb.Merge();
+            File.WriteAllBytes("emote_win2ems.psb", psb.Build());
+        }
 
         [TestMethod]
         public void TestCompareDecompile()

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -361,6 +361,27 @@ namespace FreeMote.Tests
         }
 
         [TestMethod]
+        public void TestDecompileMenuPsb()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            var path = Path.Combine(resPath, "title.pimg");
+            var json = PsbDecompiler.Decompile(path, out var resources);
+            foreach (var resourceMetadata in resources)
+            {
+                var res = resourceMetadata;
+            }
+        }
+
+        [TestMethod]
+        public void TestCompileMenuPsb()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+
+            var path = Path.Combine(resPath, "title.psb.json");
+            PsbCompiler.CompileToFile(path, path + ".psbuild.psb", null, 2);
+        }
+
+        [TestMethod]
         public void TestCompareDecompile()
         {
             var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -346,11 +346,7 @@ namespace FreeMote.Tests
         {
             var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
             var path = Path.Combine(resPath, "title.pimg");
-            var json = PsbDecompiler.Decompile(path, out var resources);
-            foreach (var resourceMetadata in resources)
-            {
-                var res = resourceMetadata;
-            }
+            var json = PsbDecompiler.Decompile(path, out var psb);
         }
 
         [TestMethod]

--- a/FreeMote.Tests/PsBuildTest.cs
+++ b/FreeMote.Tests/PsBuildTest.cs
@@ -130,25 +130,6 @@ namespace FreeMote.Tests
         }
 
         [TestMethod]
-        public void TestDxt5Uncompress()
-        {
-            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-            var rawDxt = Path.Combine(resPath, "D愛子a_春服-pure", "0.raw");
-            var rawBytes = File.ReadAllBytes(rawDxt);
-            RL.ConvertToImageFile(rawBytes, rawDxt + "-convert.png", 4096, 4096, PsbImageFormat.Png, PsbPixelFormat.DXT5);
-        }
-
-        [TestMethod]
-        public void TestDxt5Compress()
-        {
-            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-            var rawPng = Path.Combine(resPath, "D愛子a_春服-pure", "0.png");
-            Bitmap bitmap = new Bitmap(rawPng);
-            var bc3Bytes = DxtUtil.Dxt5Encode(bitmap);
-            RL.ConvertToImageFile(bc3Bytes, rawPng + "-convert.png", 4096, 4096, PsbImageFormat.Png, PsbPixelFormat.DXT5);
-        }
-
-        [TestMethod]
         public void TestGraft()
         {
             var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");

--- a/FreeMote.Tests/PsbTest.cs
+++ b/FreeMote.Tests/PsbTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FreeMote.Psb;
 
@@ -85,48 +82,7 @@ namespace FreeMote.Tests
                 PSB psb = new PSB(fs);
             }
         }
-
-        [TestMethod]
-        public void TestRlUncompress()
-        {
-            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-
-            var path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "84.bin"); //輪郭00
-            RL.UncompressToImageFile(File.ReadAllBytes(path), path + ".png", 570, 426);
-            path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "89.bin"); //胸00
-            RL.UncompressToImageFile(File.ReadAllBytes(path), path + ".png", 395, 411);
-        }
-
-        [TestMethod]
-        public void TestRlCompress()
-        {
-            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-            string path;
-            byte[] bytes;
-            path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "84.bin"); //輪郭00
-            RL.UncompressToImageFile(File.ReadAllBytes(path), path + ".png", 570, 426);
-            bytes = RL.CompressImageFile(path + ".png");
-            File.WriteAllBytes(path + ".rl", bytes);
-            RL.UncompressToImageFile(File.ReadAllBytes(path + ".rl"), path + ".rl.png", 570, 426);
-            Assert.IsTrue(bytes.SequenceEqual(File.ReadAllBytes(path)));
-
-            path = Path.Combine(resPath, "澄怜a_裸.psb-pure", "89.bin"); //胸00
-            RL.UncompressToImageFile(File.ReadAllBytes(path), path + ".png", 395, 411);
-            bytes = RL.CompressImageFile(path + ".png");
-            File.WriteAllBytes(path + ".rl", bytes);
-            RL.UncompressToImageFile(File.ReadAllBytes(path + ".rl"), path + ".rl.png", 395, 411);
-            Assert.IsTrue(bytes.SequenceEqual(File.ReadAllBytes(path)));
-        }
-
-        [TestMethod]
-        public void TestRlDirectCompress()
-        {
-            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
-            var path = Path.Combine(resPath, "emote_test2-pure", "tex-texture.png");
-            var bytes = RL.CompressImageFile(path, PsbPixelFormat.CommonRGBA8);
-            File.WriteAllBytes(path + ".rl", bytes);
-        }
-
+        
         [TestMethod]
         public void TestPsbNumbers()
         {

--- a/FreeMote.Tests/PsbTest.cs
+++ b/FreeMote.Tests/PsbTest.cs
@@ -17,9 +17,6 @@ namespace FreeMote.Tests
     {
         public PsbTest()
         {
-            //
-            //TODO:  在此处添加构造函数逻辑
-            //
         }
 
         private TestContext testContextInstance;
@@ -119,6 +116,15 @@ namespace FreeMote.Tests
             File.WriteAllBytes(path + ".rl", bytes);
             RL.UncompressToImageFile(File.ReadAllBytes(path + ".rl"), path + ".rl.png", 395, 411);
             Assert.IsTrue(bytes.SequenceEqual(File.ReadAllBytes(path)));
+        }
+
+        [TestMethod]
+        public void TestRlDirectCompress()
+        {
+            var resPath = Path.Combine(Environment.CurrentDirectory, @"..\..\Res");
+            var path = Path.Combine(resPath, "emote_test2-pure", "tex-texture.png");
+            var bytes = RL.CompressImageFile(path, PsbPixelFormat.CommonRGBA8);
+            File.WriteAllBytes(path + ".rl", bytes);
         }
 
         [TestMethod]

--- a/FreeMote.Tests/PsbTest.cs
+++ b/FreeMote.Tests/PsbTest.cs
@@ -137,7 +137,7 @@ namespace FreeMote.Tests
                 BinaryReader br = new BinaryReader(ms);
                 p1.WriteTo(bw);
                 ms.Seek(0, SeekOrigin.Begin);
-                var p2 = new PsbNumber((PsbType)br.ReadByte(), br);
+                var p2 = new PsbNumber((PsbObjType)br.ReadByte(), br);
                 Assert.AreEqual(p1.IntValue, p2.IntValue);
             }
         }

--- a/FreeMote.Tools.EmotePsbConverter/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.EmotePsbConverter/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Project AZUSA  2017")]
+[assembly: AssemblyCopyright("Copyright © Project AZUSA 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.Tools.PsBuild/Program.cs
+++ b/FreeMote.Tools.PsBuild/Program.cs
@@ -7,7 +7,7 @@ namespace FreeMote.Tools.PsBuild
     class Program
     {
         //Not thread safe
-        private static PsbSpec _platform = PsbSpec.win;
+        private static PsbSpec? _platform = null;
         //private static PsbPixelFormat _pixelFormat = PsbPixelFormat.None;
         private static uint? _key = null;
         private static ushort _version = 3;
@@ -32,7 +32,7 @@ namespace FreeMote.Tools.PsBuild
                 }
                 else if (s.StartsWith("/v"))
                 {
-                    if (ushort.TryParse(s.Replace("/v",""), out var ver))
+                    if (ushort.TryParse(s.Replace("/v", ""), out var ver))
                     {
                         _version = ver;
                     }
@@ -70,14 +70,15 @@ namespace FreeMote.Tools.PsBuild
         private static void Compile(string s)
         {
             var name = Path.GetFileNameWithoutExtension(s);
+            var ext = Path.GetExtension(s);
             Console.WriteLine($"Compiling {name} ...");
             try
             {
-                PsbCompiler.CompileToFile(s, s + (_key == null? "-pure.psb" : ".psb"), null, _version, _key, _platform);
+                PsbCompiler.CompileToFile(s, s + (_key == null ? "-pure.psb" : ".psb"), null, _version, _key, _platform);
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Compile {name} failed.");
+                Console.WriteLine($"Compile {name} failed.\r\n{e}");
             }
             Console.WriteLine($"Compile {name} succeed.");
         }
@@ -88,7 +89,7 @@ namespace FreeMote.Tools.PsBuild
             Console.WriteLine(@"Param:
 /v<VerNumber> : Set compile version from [2,4] . Default: 3.
 /k<CryptKey> : Set CryptKey. Default: none(Pure PSB). Requirement: uint, dec.
-/p<Platform> : Set platform. Default: keep original platform. Support: krkr/win/common.
+/p<Platform> : Set platform. Default: keep original platform. Support: krkr/win/common/ems.
 Warning: Platform ONLY works with .bmp/.png format textures.
 ");
             Console.WriteLine("Example: PsBuild /v4 /k123456789 /pkrkr emote_sample.psb.json");

--- a/FreeMote.Tools.PsBuild/Program.cs
+++ b/FreeMote.Tools.PsBuild/Program.cs
@@ -10,7 +10,7 @@ namespace FreeMote.Tools.PsBuild
         private static PsbSpec? _platform = null;
         //private static PsbPixelFormat _pixelFormat = PsbPixelFormat.None;
         private static uint? _key = null;
-        private static ushort _version = 3;
+        private static ushort? _version = null;
 
         static void Main(string[] args)
         {

--- a/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsBuild/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
 [assembly: AssemblyTitle("FreeMote.Tools.PsBuild")]
-[assembly: AssemblyDescription("Emote PSB Compiler")]
+[assembly: AssemblyDescription("PSB Compiler")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Project AZUSA  2017")]
+[assembly: AssemblyCopyright("Copyright © Project AZUSA 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
+++ b/FreeMote.Tools.PsbDecompile/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // 控制。更改这些特性值可修改
 // 与程序集关联的信息。
 [assembly: AssemblyTitle("FreeMote.Tools.PsbDecompile")]
-[assembly: AssemblyDescription("Emote PSB Decompiler")]
+[assembly: AssemblyDescription("PSB Decompiler")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Project AZUSA  2017")]
+[assembly: AssemblyCopyright("Copyright © Project AZUSA 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote.sln
+++ b/FreeMote.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeMote.Psb", "FreeMote.Psb\FreeMote.Psb.csproj", "{C0B2C2FF-D8F4-497E-8312-C2AF1BB6E7F7}"
 EndProject
@@ -54,5 +54,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8FD8E370-07FE-48AE-83D3-C460B9522FFA}
 	EndGlobalSection
 EndGlobal

--- a/FreeMote/FreeMote.csproj
+++ b/FreeMote/FreeMote.csproj
@@ -51,6 +51,7 @@
     <Compile Include="PixelCompress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PsbConstants.cs" />
+    <Compile Include="PsbEnums.cs" />
     <Compile Include="PsbFile.cs" />
     <Compile Include="PsbHeader.cs" />
     <Compile Include="PsbStreamContext.cs" />

--- a/FreeMote/FreeMote.csproj
+++ b/FreeMote/FreeMote.csproj
@@ -48,7 +48,7 @@
     <Compile Include="BTree.cs" />
     <Compile Include="DxtCodec.cs" />
     <Compile Include="DxtUtil.cs" />
-    <Compile Include="PixelCompress.cs" />
+    <Compile Include="RleCompress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PsbConstants.cs" />
     <Compile Include="PsbEnums.cs" />

--- a/FreeMote/FreeMote.csproj
+++ b/FreeMote/FreeMote.csproj
@@ -56,6 +56,7 @@
     <Compile Include="PsbHeader.cs" />
     <Compile Include="PsbStreamContext.cs" />
     <Compile Include="RL.cs" />
+    <Compile Include="TlgImageConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FreeMote/PixelCompress.cs
+++ b/FreeMote/PixelCompress.cs
@@ -147,7 +147,7 @@ namespace FreeMote
             {
                 return BitConverter.ToUInt32(b1, 0) == BitConverter.ToUInt32(b2, 0);
             }
-            return !b1.Where((t, i) => t != b2[i]).Any();
+            return b1.SequenceEqual(b2);
         }
 
 

--- a/FreeMote/Properties/AssemblyInfo.cs
+++ b/FreeMote/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.*")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/FreeMote/Properties/AssemblyInfo.cs
+++ b/FreeMote/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Ulysses  2017-2018")]
+[assembly: AssemblyCopyright("Copyright © Ulysses 2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote/Properties/AssemblyInfo.cs
+++ b/FreeMote/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Project AZUSA")]
 [assembly: AssemblyProduct("FreeMote")]
-[assembly: AssemblyCopyright("Copyright © Ulysses  2017")]
+[assembly: AssemblyCopyright("Copyright © Ulysses  2017-2018")]
 [assembly: AssemblyTrademark("wdwxy12345@gmail.com")]
 [assembly: AssemblyCulture("")]
 

--- a/FreeMote/PsbConstants.cs
+++ b/FreeMote/PsbConstants.cs
@@ -7,17 +7,6 @@ using System.Linq;
 
 namespace FreeMote
 {
-    /// <summary>
-    /// PSB Platform
-    /// </summary>
-    public enum PsbSpec : byte
-    {
-        common,
-        krkr,
-        win,
-        other = Byte.MaxValue,
-    }
-
     public static class PsbConstants
     {
         /// <summary>

--- a/FreeMote/PsbEnums.cs
+++ b/FreeMote/PsbEnums.cs
@@ -4,6 +4,23 @@
 
 namespace FreeMote
 {
+    public enum PsbType
+    {
+        /// <summary>
+        /// Motion
+        /// </summary>
+        Motion = 0,
+        /// <summary>
+        /// Images
+        /// </summary>
+        Pimg = 1,
+        /// <summary>
+        /// Script
+        /// </summary>
+        /// TODO: KS decompiler?
+        Scn = 2,
+    }
+
     /// <summary>
     /// PSB Platform
     /// </summary>

--- a/FreeMote/PsbEnums.cs
+++ b/FreeMote/PsbEnums.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+// ReSharper disable InconsistentNaming
+
+namespace FreeMote
+{
+    /// <summary>
+    /// PSB Platform
+    /// </summary>
+    public enum PsbSpec : byte
+    {
+        /// <summary>
+        /// Unity & other
+        /// </summary>
+        common,
+        /// <summary>
+        /// Kirikiri
+        /// </summary>
+        krkr,
+        /// <summary>
+        /// DirectX
+        /// </summary>
+        win,
+        /// <summary>
+        /// WebGL
+        /// </summary>
+        ems,
+        other = Byte.MaxValue,
+    }
+
+    public enum PsbImageFormat
+    {
+        Bmp,
+        Png,
+    }
+
+    public enum PsbPixelFormat
+    {
+        None,
+        /// <summary>
+        /// Little Endian RGBA8
+        /// </summary>
+        WinRGBA8,
+        /// <summary>
+        /// Big Endian RGBA8
+        /// </summary>
+        CommonRGBA8,
+        /// <summary>
+        /// RGBA4444
+        /// </summary>
+        RGBA4444,
+        /// <summary>
+        /// Big Endian DXT5
+        /// </summary>
+        DXT5,
+    }
+}

--- a/FreeMote/PsbEnums.cs
+++ b/FreeMote/PsbEnums.cs
@@ -70,5 +70,13 @@ namespace FreeMote
         /// Big Endian DXT5
         /// </summary>
         DXT5,
+        /// <summary>
+        /// Unsupport
+        /// </summary>
+        A8L8,
+        /// <summary>
+        /// Unsupport
+        /// </summary>
+        L8,
     }
 }

--- a/FreeMote/PsbHeader.cs
+++ b/FreeMote/PsbHeader.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace FreeMote
 {
-    [StructLayout(LayoutKind.Explicit)]
+    //[StructLayout(LayoutKind.Explicit)]
     internal class PsbHeader
     {
         /// <summary>
@@ -13,71 +13,86 @@ namespace FreeMote
         /// </summary>
         public const int MAX_HEADER_LENGTH = 56;
 
-        [FieldOffset(0)] public char[] Signature = { 'P', 'S', 'B', (char)0 };
+        //[FieldOffset(0)] //This will cause error on x64 CLR since the next FieldOffset after char[] have to be 8n.
+        public char[] Signature = {'P', 'S', 'B', '\0'};
 
-        [FieldOffset(4)] public ushort Version = 3;
+        //[FieldOffset(4)]
+        public ushort Version = 3;
 
         /// <summary>
         /// If 1, the header seems encrypted, which add more difficulty to us
         /// <para>But doesn't really matters since usually it's always encrypted in v3+</para>
         /// </summary>
-        [FieldOffset(6)] public ushort HeaderEncrypt = 0;
+        //[FieldOffset(6)]
+        public ushort HeaderEncrypt = 0;
 
         /// <summary>
         /// Header Length
         /// <para>Usually same as <see cref="OffsetNames"/></para>
         /// </summary>
-        [FieldOffset(8)] public uint HeaderLength;
+        //[FieldOffset(8)]
+        public uint HeaderLength;
 
         /// <summary>
         /// Offset of Names
         /// <para>Usually the beginning of encryption in v2</para>
         /// </summary>
-        [FieldOffset(12)] public uint OffsetNames;
+        //[FieldOffset(12)]
+        public uint OffsetNames;
 
-        [FieldOffset(16)] public uint OffsetStrings;
+        //[FieldOffset(16)]
+        public uint OffsetStrings;
 
-        [FieldOffset(20)] public uint OffsetStringsData;
+        //[FieldOffset(20)]
+        public uint OffsetStringsData;
 
         /// <summary>
         /// ResOffTable
         /// </summary>
-        [FieldOffset(24)] public uint OffsetChunkOffsets;
+        //[FieldOffset(24)]
+        public uint OffsetChunkOffsets;
 
-        [FieldOffset(28)] public uint OffsetChunkLengths;
+        //[FieldOffset(28)]
+        public uint OffsetChunkLengths;
 
         /// <summary>
         /// Offset of Chunk Data (Image)
         /// </summary>
-        [FieldOffset(32)] public uint OffsetChunkData;
+        //[FieldOffset(32)]
+        public uint OffsetChunkData;
 
         /// <summary>
         /// Entry Offset
         /// </summary>
-        [FieldOffset(36)] public uint OffsetEntries;
+        //[FieldOffset(36)]
+        public uint OffsetEntries;
 
         /// <summary>
         /// [New in v3] Adler32 Checksum for header
         /// <para>Not always checked in v3. Sadly, it's always checked from v4, so we have to handle it.</para>
         /// </summary>
-        [FieldOffset(40)] public uint Checksum;
+        //[FieldOffset(40)]
+        public uint Checksum;
 
         /// <summary>
         /// [New in v4] Usually an empty array (3 bytes)
         /// <para><see cref="OffsetResourceOffsets"/> - 6</para>
         /// </summary>
-        [FieldOffset(44)] public uint OffsetUnknown1;
+        //[FieldOffset(44)]
+        public uint OffsetUnknown1;
 
         /// <summary>
         /// [New in v4] Usually an empty array (3 bytes)
         /// <para><see cref="OffsetResourceOffsets"/> - 3</para>
         /// </summary>
-        [FieldOffset(48)] public uint OffsetUnknown2;
+        //[FieldOffset(48)]
+        public uint OffsetUnknown2;
 
         /// <summary>
         /// [New in v4] Usually same as <see cref="OffsetChunkOffsets"/>
         /// </summary>
-        [FieldOffset(52)] public uint OffsetResourceOffsets;
+        //[FieldOffset(52)]
+        public uint OffsetResourceOffsets;
 
 
         public static PsbHeader Load(BinaryReader br)

--- a/FreeMote/RL.cs
+++ b/FreeMote/RL.cs
@@ -5,33 +5,6 @@ using System.IO;
 
 namespace FreeMote
 {
-    public enum PsbImageFormat
-    {
-        Bmp,
-        Png,
-    }
-
-    public enum PsbPixelFormat
-    {
-        None,
-        /// <summary>
-        /// Little Endian RGBA8
-        /// </summary>
-        WinRGBA8,
-        /// <summary>
-        /// Big Endian RGBA8
-        /// </summary>
-        CommonRGBA8,
-        /// <summary>
-        /// RGBA4444
-        /// </summary>
-        RGBA4444,
-        /// <summary>
-        /// Big Endian DXT5
-        /// </summary>
-        DXT5,
-    }
-
     /// <summary>
     /// RL Compress for Image
     /// </summary>

--- a/FreeMote/RleCompress.cs
+++ b/FreeMote/RleCompress.cs
@@ -5,16 +5,16 @@ using System.Linq;
 namespace FreeMote
 {
     /// <summary>
-    /// PSB Pixel Compress (for images)
+    /// RLE Compress
     /// <para>originally by number201724</para>
     /// </summary>
-    internal static class PixelCompress
+    internal static class RleCompress
     {
         public const int LzssLookShift = 7;
         public const int LzssLookAhead = 1 << LzssLookShift;
 
         /// <summary>
-        /// Pixel Uncompress
+        /// RLE Uncompress
         /// </summary>
         /// <param name="input"></param>
         /// <param name="actualSize"></param>
@@ -152,7 +152,7 @@ namespace FreeMote
 
 
         /// <summary>
-        /// Pixel Compress
+        /// RLE Compress
         /// </summary>
         /// <param name="input"></param>
         /// <param name="align"></param>

--- a/FreeMote/TlgImageConverter.cs
+++ b/FreeMote/TlgImageConverter.cs
@@ -207,9 +207,9 @@ namespace FreeMote
             if (string.IsNullOrEmpty (baseName))
                 return null;
 
-            throw new NotImplementedException("Blend Images are not supported yet.");
             Console.WriteLine($"[Missing] {meta.FileName}/{baseName}");
-            return null;
+            throw new NotImplementedException("Blend Images are not supported yet.");
+            //return null;
 
             /*
             baseName = VFS.CombinePath (VFS.GetDirectoryName (meta.FileName), baseName);
@@ -697,10 +697,10 @@ namespace FreeMote
                 switch (filtertypes[filtertypesIndex+i])
                 {
                 case 0:
-                    decoder = (a, b, c, v) => tvp_med (a, b, c, v);
+                    decoder = tvp_med;
                     break;
                 case 1:
-                    decoder = (a, b, c, v) => tvp_avg (a, b, c, v);
+                    decoder = tvp_avg;
                     break;
                 case 2:
                     decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)

--- a/FreeMote/TlgImageConverter.cs
+++ b/FreeMote/TlgImageConverter.cs
@@ -1,0 +1,1210 @@
+﻿//! \file       ImageTLG.cs
+//! \date       Thu Jul 17 21:31:39 2014
+//! \brief      KiriKiri TLG image implementation.
+//---------------------------------------------------------------------------
+// TLG5/6 decoder
+//	Copyright (C) 2000-2005  W.Dee <dee@kikyou.info> and contributors
+//
+// C# port by morkt (https://github.com/morkt/GARbro) LICENSE: MIT
+// Modified by Ulysses (wdwxy12345@gmail.com)
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FreeMote
+{
+    internal static class GameResExtension
+    {
+        public static bool AsciiEqual(this byte[] array, int offset, string str)
+        {
+            var strArr = Encoding.ASCII.GetBytes(str);
+            if (array.Length < strArr.Length + offset)
+            {
+                return false;
+            }
+            return array.Skip(offset).Take(strArr.Length).SequenceEqual(strArr);
+        }
+
+        public static bool AsciiEqual(this byte[] array, string str)
+        {
+            var strArr = Encoding.ASCII.GetBytes(str);
+            if (array.Length < strArr.Length)
+            {
+                return false;
+            }
+            return array.Take(strArr.Length).SequenceEqual(strArr);
+        }
+
+        public static uint ToUInt32(this byte[] array, int offset)
+        {
+            return BitConverter.ToUInt32(array, offset);
+        }
+
+    }
+
+    internal class TlgMetaData
+    {
+        public int Bpp;
+        public int Version;
+        public int DataOffset;
+        public uint Width;
+        public uint Height;
+        public string FileName;
+        public int OffsetX;
+        public int OffsetY;
+
+    }
+
+    public class TlgImageConverter
+    {
+        public string Tag { get { return "TLG"; } }
+        public string Description { get { return "KiriKiri game engine image format"; } }
+        public uint Signature { get { return 0x30474c54; } } // "TLG0"
+
+        public TlgImageConverter()
+        {
+            Extensions = new string[] { "tlg", "tlg5", "tlg6" };
+            Signatures = new uint[] { 0x30474c54, 0x35474c54, 0x36474c54, 0x35474cAB };
+        }
+
+        public uint[] Signatures { get; set; }
+
+        public string[] Extensions { get; set; }
+
+        internal TlgMetaData ReadMetaData (BinaryReader br)
+        {
+            br.BaseStream.Seek(0, SeekOrigin.Begin);
+            var header = br.ReadBytes(38);
+            int offset = 0xf;
+            if (!header.AsciiEqual ("TLG0.0\x00sds\x1a"))
+                offset = 0;
+            int version;
+            if (!header.AsciiEqual (offset+6, "\x00raw\x1a"))
+                return null;
+            if (0xAB == header[offset])
+                header[offset] = (byte)'T';
+            if (header.AsciiEqual (offset, "TLG6.0"))
+                version = 6;
+            else if (header.AsciiEqual (offset, "TLG5.0"))
+                version = 5;
+            else if (header.AsciiEqual (offset, "XXXYYY"))
+            {
+                version = 5;
+                header[offset+0x0C] ^= 0xAB;
+                header[offset+0x10] ^= 0xAC;
+            }
+            else if (header.AsciiEqual (offset, "XXXZZZ"))
+            {
+                version = 6;
+                header[offset+0x0F] ^= 0xAB;
+                header[offset+0x13] ^= 0xAC;
+            }
+            else
+                return null;
+            int colors = header[offset+11];
+            if (6 == version)
+            {
+                if (1 != colors && 4 != colors && 3 != colors)
+                    return null;
+                if (header[offset+12] != 0 || header[offset+13] != 0 || header[offset+14] != 0)
+                    return null;
+                offset += 15;
+            }
+            else
+            {
+                if (4 != colors && 3 != colors)
+                    return null;
+                offset += 12;
+            }
+            return new TlgMetaData
+            {
+                Width   = header.ToUInt32 (offset),
+                Height  = header.ToUInt32 (offset+4),
+                Bpp     = colors*8,
+                Version     = version,
+                DataOffset  = offset+8,
+            };
+        }
+
+        public Bitmap Read (BinaryReader file)
+        {
+            TlgMetaData meta = ReadMetaData(file);
+            var image = ReadTlg (file, meta);
+
+            int tailSize = (int)Math.Min (file.BaseStream.Length - file.BaseStream.Position, 512);
+            if (tailSize > 8)
+            {
+                var tail = file.ReadBytes (tailSize);
+                try
+                {
+                    var blendedImage = ApplyTags (image, meta, tail);
+                    if (null != blendedImage)
+                        return blendedImage;
+                }
+                catch (FileNotFoundException x)
+                {
+                    Trace.WriteLine (string.Format ("{0}: {1}", x.Message, x.FileName), "[TlgFormat.Read]");
+                }
+                catch (Exception x)
+                {
+                    Trace.WriteLine (x.Message, "[TlgFormat.Read]");
+                }
+            }
+            //PixelFormat format = 32 == meta.BPP ? PixelFormats.Bgra32 : PixelFormats.Bgr32;
+            PixelFormat format = 32 == meta.Bpp ? PixelFormat.Format32bppArgb : PixelFormat.Format32bppRgb;
+            return CreateImage (meta, format, image, (int)meta.Width * 4);
+        }
+
+        private unsafe Bitmap CreateImage(TlgMetaData meta, PixelFormat format, byte[] image, int stride)
+        {
+            Bitmap bmp;
+            fixed (byte* p = image)
+            {
+                IntPtr ptr = (IntPtr)p;
+                bmp = new Bitmap((int)meta.Width, (int)meta.Height, stride, format, ptr);
+            }
+
+            return bmp;
+        }
+
+        public byte[] Write (BinaryReader file)
+        {
+            throw new NotImplementedException ("TlgFormat.Write not implemented");
+        }
+
+        byte[] ReadTlg (BinaryReader src, TlgMetaData info)
+        {
+            src.BaseStream.Position = info.DataOffset;
+            if (6 == info.Version)
+                return ReadV6 (src, info);
+            else
+                return ReadV5 (src, info);
+        }
+
+        Bitmap ApplyTags (byte[] image, TlgMetaData meta, byte[] tail)
+        {
+            int i = tail.Length - 8;
+            while (i >= 0)
+            {
+                if ('s' == tail[i+3] && 'g' == tail[i+2] && 'a' == tail[i+1] && 't' == tail[i])
+                    break;
+                --i;
+            }
+            if (i < 0)
+                return null;
+            var tags = new TagsParser (tail, i+4);
+            if (!tags.Parse())
+                return null;
+            var baseName   = tags.GetString (1);
+            meta.OffsetX    = tags.GetInt (2) & 0xFFFF;
+            meta.OffsetY    = tags.GetInt (3) & 0xFFFF;
+            if (string.IsNullOrEmpty (baseName))
+                return null;
+
+            throw new NotImplementedException("Blend Images are not supported yet.");
+            Console.WriteLine($"[Missing] {meta.FileName}/{baseName}");
+            return null;
+
+            /*
+            baseName = VFS.CombinePath (VFS.GetDirectoryName (meta.FileName), baseName);
+            if (baseName == meta.FileName)
+                return null;
+
+            TlgMetaData base_info;
+            byte[] base_image;
+            using (BinaryReader base_file = VFS.OpenBinaryStream (baseName))
+            {
+                base_info = ReadMetaData (base_file) as TlgMetaData;
+                if (null == base_info)
+                    return null;
+                base_info.FileName = baseName;
+                base_image = ReadTlg (base_file, base_info);
+            }
+            var pixels = BlendImage (base_image, base_info, image, meta);
+            //PixelFormat format = 32 == base_info.BPP ? PixelFormats.Bgra32 : PixelFormats.Bgr32;
+            PixelFormat format = 32 == meta.BPP ? PixelFormat.Format32bppArgb : PixelFormat.Format32bppRgb;
+            return CreateImage (base_info, format, pixels, (int)base_info.Width*4);
+        */
+        }
+
+        byte[] BlendImage(byte[] baseImage, TlgMetaData baseInfo, byte[] overlay, TlgMetaData overlayInfo)
+        {
+            int dstStride = (int)baseInfo.Width * 4;
+            int srcStride = (int)overlayInfo.Width * 4;
+            int dst = overlayInfo.OffsetY * dstStride + overlayInfo.OffsetX * 4;
+            int src = 0;
+            int gap = dstStride - srcStride;
+            for (uint y = 0; y < overlayInfo.Height; ++y)
+            {
+                for (uint x = 0; x < overlayInfo.Width; ++x)
+                {
+                    byte srcAlpha = overlay[src+3];
+                    if (srcAlpha != 0)
+                    {
+                        if (0xFF == srcAlpha || 0 == baseImage[dst+3])
+                        {
+                            baseImage[dst]   = overlay[src];
+                            baseImage[dst+1] = overlay[src+1];
+                            baseImage[dst+2] = overlay[src+2];
+                            baseImage[dst+3] = srcAlpha;
+                        }
+                        else
+                        {
+                            // FIXME this blending algorithm is oversimplified.
+                            baseImage[dst+0] = (byte)((overlay[src+0] * srcAlpha
+                                              + baseImage[dst+0] * (0xFF - srcAlpha)) / 0xFF);
+                            baseImage[dst+1] = (byte)((overlay[src+1] * srcAlpha
+                                              + baseImage[dst+1] * (0xFF - srcAlpha)) / 0xFF);
+                            baseImage[dst+2] = (byte)((overlay[src+2] * srcAlpha
+                                              + baseImage[dst+2] * (0xFF - srcAlpha)) / 0xFF);
+                            baseImage[dst+3] = (byte)Math.Max (srcAlpha, baseImage[dst+3]);
+                        }
+                    }
+                    dst += 4;
+                    src += 4;
+                }
+                dst += gap;
+            }
+            return baseImage;
+        }
+
+        const int TVP_TLG6_H_BLOCK_SIZE = 8;
+        const int TVP_TLG6_W_BLOCK_SIZE = 8;
+
+        const int TVP_TLG6_GOLOMB_N_COUNT = 4;
+        const int TVP_TLG6_LeadingZeroTable_BITS = 12;
+        const int TVP_TLG6_LeadingZeroTable_SIZE = (1<<TVP_TLG6_LeadingZeroTable_BITS);
+
+        byte[] ReadV6 (BinaryReader src, TlgMetaData info)
+        {
+            int width = (int)info.Width;
+            int height = (int)info.Height;
+            int colors = info.Bpp / 8;
+            int maxBitLength = src.ReadInt32();
+
+            int xBlockCount = ((width - 1)/ TVP_TLG6_W_BLOCK_SIZE) + 1;
+            int yBlockCount = ((height - 1)/ TVP_TLG6_H_BLOCK_SIZE) + 1;
+            int mainCount = width / TVP_TLG6_W_BLOCK_SIZE;
+            int fraction = width -  mainCount * TVP_TLG6_W_BLOCK_SIZE;
+
+            var imageBits = new uint[height * width];
+            var bitPool = new byte[maxBitLength / 8 + 5];
+            var pixelbuf = new uint[width * TVP_TLG6_H_BLOCK_SIZE + 1];
+            var filterTypes = new byte[xBlockCount * yBlockCount];
+            var zeroline = new uint[width];
+            var lzssText = new byte[4096];
+
+            // initialize zero line (virtual y=-1 line)
+            uint zerocolor = 3 == colors ? 0xff000000 : 0x00000000;
+            for (var i = 0; i < width; ++i)
+                zeroline[i] = zerocolor;
+
+            uint[] prevline = zeroline;
+            int prevlineIndex = 0;
+
+            // initialize LZSS text (used by chroma filter type codes)
+            int p = 0;
+            for (uint i = 0; i < 32*0x01010101; i += 0x01010101)
+            {
+                for (uint j = 0; j < 16*0x01010101; j += 0x01010101)
+                {
+                    lzssText[p++] = (byte)(i       & 0xff);
+                    lzssText[p++] = (byte)(i >> 8  & 0xff);
+                    lzssText[p++] = (byte)(i >> 16 & 0xff);
+                    lzssText[p++] = (byte)(i >> 24 & 0xff);
+                    lzssText[p++] = (byte)(j       & 0xff);
+                    lzssText[p++] = (byte)(j >> 8  & 0xff);
+                    lzssText[p++] = (byte)(j >> 16 & 0xff);
+                    lzssText[p++] = (byte)(j >> 24 & 0xff);
+                }
+            }
+            // read chroma filter types.
+            // chroma filter types are compressed via LZSS as used by TLG5.
+            {
+                int inbufSize = src.ReadInt32();
+                byte[] inbuf = src.ReadBytes (inbufSize);
+                if (inbufSize != inbuf.Length)
+                    return null;
+                TVPTLG5DecompressSlide (filterTypes, inbuf, inbufSize, lzssText, 0);
+            }
+
+            // for each horizontal block group ...
+            for (int y = 0; y < height; y += TVP_TLG6_H_BLOCK_SIZE)
+            {
+                int ylim = y + TVP_TLG6_H_BLOCK_SIZE;
+                if (ylim >= height) ylim = height;
+
+                int pixelCount = (ylim - y) * width;
+
+                // decode values
+                for (int c = 0; c < colors; c++)
+                {
+                    // read bit length
+                    int bitLength = src.ReadInt32();
+
+                    // get compress method
+                    int method = (bitLength >> 30) & 3;
+                    bitLength &= 0x3fffffff;
+
+                    // compute byte length
+                    int byteLength = bitLength / 8;
+                    if (0 != (bitLength % 8)) byteLength++;
+
+                    // read source from input
+                    src.Read (bitPool, 0, byteLength);
+
+                    // decode values
+                    // two most significant bits of bitlength are
+                    // entropy coding method;
+                    // 00 means Golomb method,
+                    // 01 means Gamma method (not yet suppoted),
+                    // 10 means modified LZSS method (not yet supported),
+                    // 11 means raw (uncompressed) data (not yet supported).
+
+                    switch (method)
+                    {
+                    case 0:
+                        if (c == 0 && colors != 1)
+                            TVPTLG6DecodeGolombValuesForFirst (pixelbuf, pixelCount, bitPool);
+                        else
+                            TVPTLG6DecodeGolombValues (pixelbuf, c*8, pixelCount, bitPool);
+                        break;
+                    default:
+                        throw new FormatException ("Unsupported entropy coding method");
+                    }
+                }
+
+                // for each line
+                int ft = (y / TVP_TLG6_H_BLOCK_SIZE) * xBlockCount; // within filter_types
+                int skipbytes = (ylim - y) * TVP_TLG6_W_BLOCK_SIZE;
+
+                for (int yy = y; yy < ylim; yy++)
+                {
+                    int curline = yy*width;
+
+                    int dir = (yy&1)^1;
+                    int oddskip = ((ylim - yy -1) - (yy-y));
+                    if (0 != mainCount)
+                    {
+                        int start =
+                            ((width < TVP_TLG6_W_BLOCK_SIZE) ? width : TVP_TLG6_W_BLOCK_SIZE) *
+                                (yy - y);
+                        TVPTLG6DecodeLineGeneric (
+                            prevline, prevlineIndex,
+                            imageBits, curline,
+                            width, 0, mainCount,
+                            filterTypes, ft,
+                            skipbytes,
+                            pixelbuf, start,
+                            zerocolor, oddskip, dir);
+                    }
+
+                    if (mainCount != xBlockCount)
+                    {
+                        int ww = fraction;
+                        if (ww > TVP_TLG6_W_BLOCK_SIZE) ww = TVP_TLG6_W_BLOCK_SIZE;
+                        int start = ww * (yy - y);
+                        TVPTLG6DecodeLineGeneric (
+                            prevline, prevlineIndex,
+                            imageBits, curline,
+                            width, mainCount, xBlockCount,
+                            filterTypes, ft,
+                            skipbytes,
+                            pixelbuf, start,
+                            zerocolor, oddskip, dir);
+                    }
+                    prevline = imageBits;
+                    prevlineIndex = curline;
+                }
+            }
+            int stride = width * 4;
+            var pixels = new byte[height * stride];
+            Buffer.BlockCopy (imageBits, 0, pixels, 0, pixels.Length);
+            return pixels;
+        }
+
+        byte[] ReadV5 (BinaryReader src, TlgMetaData info)
+        {
+            int width = (int)info.Width;
+            int height = (int)info.Height;
+            int colors = info.Bpp / 8;
+            int blockheight = src.ReadInt32();
+            int blockcount = (height - 1) / blockheight + 1;
+
+            // skip block size section
+            src.BaseStream.Seek (blockcount * 4, SeekOrigin.Current);
+
+            int stride = width * 4;
+            var imageBits = new byte[height * stride];
+            var text = new byte[4096];
+            for (int i = 0; i < 4096; ++i)
+                text[i] = 0;
+
+            var inbuf = new byte[blockheight * width + 10];
+            byte [][] outbuf = new byte[4][];
+            for (int i = 0; i < colors; i++)
+                outbuf[i] = new byte[blockheight * width + 10];
+
+            int z = 0;
+            int prevline = -1;
+            for (int yBlk = 0; yBlk < height; yBlk += blockheight)
+            {
+                // read file and decompress
+                for (int c = 0; c < colors; c++)
+                {
+                    byte mark = src.ReadByte();
+                    int size;
+                    size = src.ReadInt32();
+                    if (mark == 0)
+                    {
+                        // modified LZSS compressed data
+                        if (size != src.Read (inbuf, 0, size))
+                            return null;
+                        z = TVPTLG5DecompressSlide (outbuf[c], inbuf, size, text, z);
+                    }
+                    else
+                    {
+                        // raw data
+                        src.Read (outbuf[c], 0, size);
+                    }
+                }
+
+                // compose colors and store
+                int yLim = yBlk + blockheight;
+                if (yLim > height) yLim = height;
+                int outbufPos = 0;
+                for (int y = yBlk; y < yLim; y++)
+                {
+                    int current = y * stride;
+                    int currentOrg = current;
+                    if (prevline >= 0)
+                    {
+                        // not first line
+                        switch(colors)
+                        {
+                        case 3:
+                            TVPTLG5ComposeColors3To4 (imageBits, current, prevline,
+                                                        outbuf, outbufPos, width);
+                            break;
+                        case 4:
+                            TVPTLG5ComposeColors4To4 (imageBits, current, prevline,
+                                                        outbuf, outbufPos, width);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        // first line
+                        switch(colors)
+                        {
+                        case 3:
+                            for (int pr = 0, pg = 0, pb = 0, x = 0;
+                                    x < width; x++)
+                            {
+                                int b = outbuf[0][outbufPos+x];
+                                int g = outbuf[1][outbufPos+x];
+                                int r = outbuf[2][outbufPos+x];
+                                b += g; r += g;
+                                imageBits[current++] = (byte)(pb += b);
+                                imageBits[current++] = (byte)(pg += g);
+                                imageBits[current++] = (byte)(pr += r);
+                                imageBits[current++] = 0xff;
+                            }
+                            break;
+                        case 4:
+                            for (int pr = 0, pg = 0, pb = 0, pa = 0, x = 0;
+                                    x < width; x++)
+                            {
+                                int b = outbuf[0][outbufPos+x];
+                                int g = outbuf[1][outbufPos+x];
+                                int r = outbuf[2][outbufPos+x];
+                                int a = outbuf[3][outbufPos+x];
+                                b += g; r += g;
+                                imageBits[current++] = (byte)(pb += b);
+                                imageBits[current++] = (byte)(pg += g);
+                                imageBits[current++] = (byte)(pr += r);
+                                imageBits[current++] = (byte)(pa += a);
+                            }
+                            break;
+                        }
+                    }
+                    outbufPos += width;
+                    prevline = currentOrg;
+                }
+            }
+            return imageBits;
+        }
+
+        void TVPTLG5ComposeColors3To4 (byte[] outp, int outpIndex, int upper,
+                                       byte[][] buf, int bufpos, int width)
+        {
+            byte pc0 = 0, pc1 = 0, pc2 = 0;
+            byte c0, c1, c2;
+            for (int x = 0; x < width; x++)
+            {
+                c0 = buf[0][bufpos+x];
+                c1 = buf[1][bufpos+x];
+                c2 = buf[2][bufpos+x];
+                c0 += c1; c2 += c1;
+                outp[outpIndex++] = (byte)(((pc0 += c0) + outp[upper+0]) & 0xff);
+                outp[outpIndex++] = (byte)(((pc1 += c1) + outp[upper+1]) & 0xff);
+                outp[outpIndex++] = (byte)(((pc2 += c2) + outp[upper+2]) & 0xff);
+                outp[outpIndex++] = 0xff;
+                upper += 4;
+            }
+        }
+
+        void TVPTLG5ComposeColors4To4 (byte[] outp, int outpIndex, int upper,
+                                       byte[][] buf, int bufpos, int width)
+        {
+            byte pc0 = 0, pc1 = 0, pc2 = 0, pc3 = 0;
+            byte c0, c1, c2, c3;
+            for (int x = 0; x < width; x++)
+            {
+                c0 = buf[0][bufpos+x];
+                c1 = buf[1][bufpos+x];
+                c2 = buf[2][bufpos+x];
+                c3 = buf[3][bufpos+x];
+                c0 += c1; c2 += c1;
+                outp[outpIndex++] = (byte)(((pc0 += c0) + outp[upper+0]) & 0xff);
+                outp[outpIndex++] = (byte)(((pc1 += c1) + outp[upper+1]) & 0xff);
+                outp[outpIndex++] = (byte)(((pc2 += c2) + outp[upper+2]) & 0xff);
+                outp[outpIndex++] = (byte)(((pc3 += c3) + outp[upper+3]) & 0xff);
+                upper += 4;
+            }
+        }
+
+        int TVPTLG5DecompressSlide (byte[] outbuf, byte[] inbuf, int inbufSize, byte[] text, int initialr)
+        {
+            int r = initialr;
+            uint flags = 0;
+            int o = 0;
+            for (int i = 0; i < inbufSize; )
+            {
+                if (((flags >>= 1) & 256) == 0)
+                {
+                    flags = (uint)(inbuf[i++] | 0xff00);
+                }
+                if (0 != (flags & 1))
+                {
+                    int mpos = inbuf[i] | ((inbuf[i+1] & 0xf) << 8);
+                    int mlen = (inbuf[i+1] & 0xf0) >> 4;
+                    i += 2;
+                    mlen += 3;
+                    if (mlen == 18) mlen += inbuf[i++];
+
+                    while (0 != mlen--)
+                    {
+                        outbuf[o++] = text[r++] = text[mpos++];
+                        mpos &= (4096 - 1);
+                        r &= (4096 - 1);
+                    }
+                }
+                else
+                {
+                    byte c = inbuf[i++];
+                    outbuf[o++] = c;
+                    text[r++] = c;
+                    r &= (4096 - 1);
+                }
+            }
+            return r;
+        }
+
+        static uint tvp_make_gt_mask (uint a, uint b)
+        {
+            uint tmp2 = ~b;
+            uint tmp = ((a & tmp2) + (((a ^ tmp2) >> 1) & 0x7f7f7f7f) ) & 0x80808080;
+            tmp = ((tmp >> 7) + 0x7f7f7f7f) ^ 0x7f7f7f7f;
+            return tmp;
+        }
+
+        static uint tvp_packed_bytes_add (uint a, uint b)
+        {
+            uint tmp = (uint)((((a & b)<<1) + ((a ^ b) & 0xfefefefe) ) & 0x01010100);
+            return a+b-tmp;
+        }
+
+        static uint tvp_med2 (uint a, uint b, uint c)
+        {
+            /* do Median Edge Detector   thx, Mr. sugi  at    kirikiri.info */
+            uint aa_gt_bb = tvp_make_gt_mask(a, b);
+            uint a_xor_b_and_aa_gt_bb = ((a ^ b) & aa_gt_bb);
+            uint aa = a_xor_b_and_aa_gt_bb ^ a;
+            uint bb = a_xor_b_and_aa_gt_bb ^ b;
+            uint n = tvp_make_gt_mask(c, bb);
+            uint nn = tvp_make_gt_mask(aa, c);
+            uint m = ~(n | nn);
+            return (n & aa) | (nn & bb) | ((bb & m) - (c & m) + (aa & m));
+        }
+
+        static uint tvp_med (uint a, uint b, uint c, uint v)
+        {
+            return tvp_packed_bytes_add (tvp_med2 (a, b, c), v);
+        }
+
+        static uint tvp_avg (uint a, uint b, uint c, uint v)
+        {
+            return tvp_packed_bytes_add ((((a&b) + (((a^b) & 0xfefefefe) >> 1)) + ((a^b)&0x01010101)), v);
+        }
+
+        delegate uint TvpDecoder (uint a, uint b, uint c, uint v);
+
+        void TVPTLG6DecodeLineGeneric (uint[] prevline, int prevlineIndex,
+                                       uint[] curline, int curlineIndex,
+                                       int width, int startBlock, int blockLimit,
+                                       byte[] filtertypes, int filtertypesIndex,
+                                       int skipblockbytes,
+                                       uint[] inbuf, int inbufIndex,
+                                       uint initialp, int oddskip, int dir)
+        {
+            /*
+                chroma/luminosity decoding
+                (this does reordering, color correlation filter, MED/AVG  at a time)
+            */
+            uint p, up;
+
+            if (0 != startBlock)
+            {
+                prevlineIndex += startBlock * TVP_TLG6_W_BLOCK_SIZE;
+                curlineIndex  += startBlock * TVP_TLG6_W_BLOCK_SIZE;
+                p  = curline[curlineIndex-1];
+                up = prevline[prevlineIndex-1];
+            }
+            else
+            {
+                p = up = initialp;
+            }
+
+            inbufIndex += skipblockbytes * startBlock;
+            int step = 0 != (dir & 1) ? 1 : -1;
+
+            for (int i = startBlock; i < blockLimit; i++)
+            {
+                int w = width - i*TVP_TLG6_W_BLOCK_SIZE;
+                if (w > TVP_TLG6_W_BLOCK_SIZE) w = TVP_TLG6_W_BLOCK_SIZE;
+                int ww = w;
+                if (step == -1) inbufIndex += ww-1;
+                if (0 != (i & 1)) inbufIndex += oddskip * ww;
+
+                TvpDecoder decoder;
+                switch (filtertypes[filtertypesIndex+i])
+                {
+                case 0:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, v);
+                    break;
+                case 1:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, v);
+                    break;
+                case 2:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (((v>>8)&0xff)<<8) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 3:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (((v>>8)&0xff)<<8) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 4:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 5:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 6:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 7:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 8:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 9:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 10:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 11:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 12:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 13:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 14:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 15:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 16:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 17:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 18:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 19:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 20:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 21:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 22:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 23:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 24:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 25:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 26:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 27:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 28:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff)+((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 29:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+(v&0xff)+((v>>8)&0xff)+((v>>16)&0xff))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v>>16)&0xff))<<8)) + (0xff & ((v&0xff)+((v>>8)&0xff)+((v>>16)&0xff))) + ((v&0xff000000))));
+                    break;
+                case 30:
+                    decoder = (a, b, c, v) => tvp_med (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v&0xff)<<1))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v&0xff)<<1))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                case 31:
+                    decoder = (a, b, c, v) => tvp_avg (a, b, c, (uint)
+                        ((0xff0000 & ((((v>>16)&0xff)+((v&0xff)<<1))<<16)) + (0xff00 & ((((v>>8)&0xff)+((v&0xff)<<1))<<8)) + (0xff & ((v&0xff))) + ((v&0xff000000))));
+                    break;
+                default: return;
+                }
+                do {
+                    uint u = prevline[prevlineIndex];
+                    p = decoder (p, u, up, inbuf[inbufIndex]);
+                    up = u;
+                    curline[curlineIndex] = p;
+                    curlineIndex++;
+                    prevlineIndex++;
+                    inbufIndex += step;
+                } while (0 != --w);
+                if (step == 1)
+                    inbufIndex += skipblockbytes - ww;
+                else
+                    inbufIndex += skipblockbytes + 1;
+                if (0 != (i&1)) inbufIndex -= oddskip * ww;
+            }
+        }
+
+        static class TvpTables
+        {
+            public static byte[] TVPTLG6LeadingZeroTable = new byte[TVP_TLG6_LeadingZeroTable_SIZE];
+            public static sbyte[,] TVPTLG6GolombBitLengthTable = new sbyte
+                [TVP_TLG6_GOLOMB_N_COUNT*2*128, TVP_TLG6_GOLOMB_N_COUNT];
+            static short[,] TVPTLG6GolombCompressed = new short[TVP_TLG6_GOLOMB_N_COUNT,9] {
+                    {3,7,15,27,63,108,223,448,130,},
+                    {3,5,13,24,51,95,192,384,257,},
+                    {2,5,12,21,39,86,155,320,384,},
+                    {2,3,9,18,33,61,129,258,511,},
+                /* Tuned by W.Dee, 2004/03/25 */
+            };
+
+            static TvpTables ()
+            {
+                TVPTLG6InitLeadingZeroTable();
+                TVPTLG6InitGolombTable();
+            }
+
+            static void TVPTLG6InitLeadingZeroTable ()
+            {
+                /* table which indicates first set bit position + 1. */
+                /* this may be replaced by BSF (IA32 instrcution). */
+
+                for (int i = 0; i < TVP_TLG6_LeadingZeroTable_SIZE; i++)
+                {
+                    int cnt = 0;
+                    int j;
+                    for(j = 1; j != TVP_TLG6_LeadingZeroTable_SIZE && 0 == (i & j);
+                        j <<= 1, cnt++);
+                    cnt++;
+                    if (j == TVP_TLG6_LeadingZeroTable_SIZE) cnt = 0;
+                    TVPTLG6LeadingZeroTable[i] = (byte)cnt;
+                }
+            }
+
+            static void TVPTLG6InitGolombTable()
+            {
+                for (int n = 0; n < TVP_TLG6_GOLOMB_N_COUNT; n++)
+                {
+                    int a = 0;
+                    for (int i = 0; i < 9; i++)
+                    {
+                        for (int j = 0; j < TVPTLG6GolombCompressed[n,i]; j++)
+                            TVPTLG6GolombBitLengthTable[a++,n] = (sbyte)i;
+                    }
+                    if(a != TVP_TLG6_GOLOMB_N_COUNT*2*128)
+                        throw new Exception ("Invalid data initialization");   /* THIS MUST NOT BE EXECUETED! */
+                            /* (this is for compressed table data check) */
+                }
+            }
+        }
+
+        void TVPTLG6DecodeGolombValuesForFirst (uint[] pixelbuf, int pixelCount, byte[] bitPool)
+        {
+            /*
+                decode values packed in "bit_pool".
+                values are coded using golomb code.
+
+                "ForFirst" function do dword access to pixelbuf,
+                clearing with zero except for blue (least siginificant byte).
+            */
+            int bitPoolIndex = 0;
+
+            int n = TVP_TLG6_GOLOMB_N_COUNT - 1; /* output counter */
+            int a = 0; /* summary of absolute values of errors */
+
+            int bitPos = 1;
+            bool zero = 0 == (bitPool[bitPoolIndex] & 1);
+
+            for (int pixel = 0; pixel < pixelCount; )
+            {
+                /* get running count */
+                int count;
+
+                {
+                    uint t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                    int b = TvpTables.TVPTLG6LeadingZeroTable[t & (TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                    int bitCount = b;
+                    while (0 == b)
+                    {
+                        bitCount += TVP_TLG6_LeadingZeroTable_BITS;
+                        bitPos += TVP_TLG6_LeadingZeroTable_BITS;
+                        bitPoolIndex += bitPos >> 3;
+                        bitPos &= 7;
+                        t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                        b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                        bitCount += b;
+                    }
+                    bitPos += b;
+                    bitPoolIndex += bitPos >> 3;
+                    bitPos &= 7;
+
+                    bitCount --;
+                    count = 1 << bitCount;
+                    count += ((BitConverter.ToInt32 (bitPool, bitPoolIndex) >> (bitPos)) & (count-1));
+
+                    bitPos += bitCount;
+                    bitPoolIndex += bitPos >> 3;
+                    bitPos &= 7;
+                }
+                if (zero)
+                {
+                    /* zero values */
+
+                    /* fill distination with zero */
+                    do { pixelbuf[pixel++] = 0; } while (0 != --count);
+
+                    zero = !zero;
+                }
+                else
+                {
+                    /* non-zero values */
+
+                    /* fill distination with glomb code */
+
+                    do
+                    {
+                        int k = TvpTables.TVPTLG6GolombBitLengthTable[a,n];
+                        int v, sign;
+
+                        uint t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                        int bitCount;
+                        int b;
+                        if (0 != t)
+                        {
+                            b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                            bitCount = b;
+                            while (0 == b)
+                            {
+                                bitCount += TVP_TLG6_LeadingZeroTable_BITS;
+                                bitPos += TVP_TLG6_LeadingZeroTable_BITS;
+                                bitPoolIndex += bitPos >> 3;
+                                bitPos &= 7;
+                                t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                                b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                                bitCount += b;
+                            }
+                            bitCount --;
+                        }
+                        else
+                        {
+                            bitPoolIndex += 5;
+                            bitCount = bitPool[bitPoolIndex-1];
+                            bitPos = 0;
+                            t = BitConverter.ToUInt32 (bitPool, bitPoolIndex);
+                            b = 0;
+                        }
+
+                        v = (int)((bitCount << k) + ((t >> b) & ((1<<k)-1)));
+                        sign = (v & 1) - 1;
+                        v >>= 1;
+                        a += v;
+                        pixelbuf[pixel++] = (byte)((v ^ sign) + sign + 1);
+
+                        bitPos += b;
+                        bitPos += k;
+                        bitPoolIndex += bitPos >> 3;
+                        bitPos &= 7;
+
+                        if (--n < 0)
+                        {
+                            a >>= 1;
+                            n = TVP_TLG6_GOLOMB_N_COUNT - 1;
+                        }
+                    } while (0 != --count);
+                    zero = !zero;
+                }
+            }
+        }
+
+        void TVPTLG6DecodeGolombValues (uint[] pixelbuf, int offset, int pixelCount, byte[] bitPool)
+        {
+            /*
+                decode values packed in "bit_pool".
+                values are coded using golomb code.
+            */
+            uint mask = (uint)~(0xff << offset);
+            int bitPoolIndex = 0;
+
+            int n = TVP_TLG6_GOLOMB_N_COUNT - 1; /* output counter */
+            int a = 0; /* summary of absolute values of errors */
+
+            int bitPos = 1;
+            bool zero = 0 == (bitPool[bitPoolIndex] & 1);
+
+            for (int pixel = 0; pixel < pixelCount; )
+            {
+                /* get running count */
+                int count;
+
+                {
+                    uint t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                    int b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                    int bitCount = b;
+                    while (0 == b)
+                    {
+                        bitCount += TVP_TLG6_LeadingZeroTable_BITS;
+                        bitPos += TVP_TLG6_LeadingZeroTable_BITS;
+                        bitPoolIndex += bitPos >> 3;
+                        bitPos &= 7;
+                        t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                        b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                        bitCount += b;
+                    }
+                    bitPos += b;
+                    bitPoolIndex += bitPos >> 3;
+                    bitPos &= 7;
+
+                    bitCount --;
+                    count = 1 << bitCount;
+                    count += (int)((BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> (bitPos)) & (count-1));
+
+                    bitPos += bitCount;
+                    bitPoolIndex += bitPos >> 3;
+                    bitPos &= 7;
+                }
+                if (zero)
+                {
+                    /* zero values */
+
+                    /* fill distination with zero */
+                    do { pixelbuf[pixel++] &= mask; } while (0 != --count);
+
+                    zero = !zero;
+                }
+                else
+                {
+                    /* non-zero values */
+
+                    /* fill distination with glomb code */
+
+                    do
+                    {
+                        int k = TvpTables.TVPTLG6GolombBitLengthTable[a,n];
+                        int v, sign;
+
+                        uint t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                        int bitCount;
+                        int b;
+                        if (0 != t)
+                        {
+                            b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                            bitCount = b;
+                            while (0 == b)
+                            {
+                                bitCount += TVP_TLG6_LeadingZeroTable_BITS;
+                                bitPos += TVP_TLG6_LeadingZeroTable_BITS;
+                                bitPoolIndex += bitPos >> 3;
+                                bitPos &= 7;
+                                t = BitConverter.ToUInt32 (bitPool, bitPoolIndex) >> bitPos;
+                                b = TvpTables.TVPTLG6LeadingZeroTable[t&(TVP_TLG6_LeadingZeroTable_SIZE-1)];
+                                bitCount += b;
+                            }
+                            bitCount --;
+                        }
+                        else
+                        {
+                            bitPoolIndex += 5;
+                            bitCount = bitPool[bitPoolIndex-1];
+                            bitPos = 0;
+                            t = BitConverter.ToUInt32 (bitPool, bitPoolIndex);
+                            b = 0;
+                        }
+
+                        v = (int)((bitCount << k) + ((t >> b) & ((1<<k)-1)));
+                        sign = (v & 1) - 1;
+                        v >>= 1;
+                        a += v;
+                        uint c = (uint)((pixelbuf[pixel] & mask) | (uint)((byte)((v ^ sign) + sign + 1) << offset));
+                        pixelbuf[pixel++] = c;
+
+                        bitPos += b;
+                        bitPos += k;
+                        bitPoolIndex += bitPos >> 3;
+                        bitPos &= 7;
+
+                        if (--n < 0)
+                        {
+                            a >>= 1;
+                            n = TVP_TLG6_GOLOMB_N_COUNT - 1;
+                        }
+                    } while (0 != --count);
+                    zero = !zero;
+                }
+            }
+        }
+    }
+
+    internal class TagsParser
+    {
+        byte[]                              _mTags;
+        Dictionary<int, Tuple<int, int>>    _mMap = new Dictionary<int, Tuple<int, int>>();
+        int                                 _mOffset;
+
+        public TagsParser (byte[] tags, int offset)
+        {
+            _mTags = tags;
+            _mOffset = offset;
+        }
+
+        public bool Parse ()
+        {
+            int length = BitConverter.ToInt32 (_mTags, _mOffset);
+            _mOffset += 4;
+            if (length <= 0 || length > _mTags.Length - _mOffset)
+                return false;
+            while (_mOffset < _mTags.Length)
+            {
+                int keyLen = ParseInt();
+                if (keyLen < 0)
+                    return false;
+                int key;
+                switch (keyLen)
+                {
+                case 1:
+                    key = _mTags[_mOffset];
+                    break;
+                case 2:
+                    key = BitConverter.ToUInt16 (_mTags, _mOffset);
+                    break;
+                case 4:
+                    key = BitConverter.ToInt32 (_mTags, _mOffset);
+                    break;
+                default:
+                    return false;
+                }
+                _mOffset += keyLen + 1;
+                int valueLen = ParseInt();
+                if (valueLen < 0)
+                    return false;
+                _mMap[key] = Tuple.Create (_mOffset, valueLen);
+                _mOffset += valueLen + 1;
+            }
+            return _mMap.Count > 0;
+        }
+
+        int ParseInt ()
+        {
+            int colon = Array.IndexOf (_mTags, (byte)':', _mOffset);
+            if (-1 == colon)
+                return -1;
+            var lenStr = Encoding.ASCII.GetString (_mTags, _mOffset, colon-_mOffset);
+            _mOffset = colon + 1;
+            return Int32.Parse (lenStr);
+        }
+
+        public int GetInt (int key)
+        {
+            var val = _mMap[key];
+            switch (val.Item2)
+            {
+            case 0: return 0;
+            case 1: return _mTags[val.Item1];
+            case 2: return BitConverter.ToUInt16 (_mTags, val.Item1);
+            case 4: return BitConverter.ToInt32 (_mTags, val.Item1);
+            default: throw new FormatException();
+            }
+        }
+
+        public string GetString (int key)
+        {
+            var val = _mMap[key];
+            return Encoding.GetEncoding("SHIFT-JIS").GetString (_mTags, val.Item1, val.Item2);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # FreeMote
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/UlyssesWu/FreeMote?branch=master&svg=true)](https://ci.appveyor.com/project/UlyssesWu/freemote/build/artifacts)
+
 Managed Emote tool libs.
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Basic functions. Decrypt or encrypt Emote PSB files.
 ### FreeMote [(SDK)](https://github.com/Project-AZUSA/FreeMote-SDK)
 Special API libs for Emote engine, which takes _pure_ (unencrypted) PSB files as input.
 ### FreeMote.Psb
-Parse Emote PSB format.
+Parse PSB format.
 ### FreeMote.PsBuild
 Compile and decompile PSB files. Convert PSB among different platforms.
 ### FreeMote.Purify (Unreleased)
@@ -25,7 +25,7 @@ Convert Emote PSB files. A managed version of `emote_conv`(by number201724).
 ### PsbDecompile (FreeMote.Tools.PsbDecompile)
 Decompile PSB files. A managed version of `decompiler`(by number201724).
 ### PsBuild (FreeMote.Tools.PsBuild)
-Compile Emote description json to PSB. A managed version of `pcc`(by number201724).
+Compile PSB description json to PSB. A managed version of `pcc`(by number201724).
 ### [FreeMoteViewer](https://github.com/Project-AZUSA/FreeMote.NET#freemoteviewer) (FreeMote.Tools.Viewer)
 Open and render Emote _pure_ PSB.
 
@@ -48,4 +48,5 @@ FreeMote is temporarily licensed under **LGPL**. Members from Project AZUSA can 
 * Singyuen Yip for `Adler32` code.
 * @gdkchan for [DxtCodec](https://github.com/gdkchan/CEGTool/blob/master/CEGTool/DXTCodec.cs) code.
 * @mfascia for [TexturePacker](https://github.com/mfascia/TexturePacker) code.
+* @morkt for [ImageTLG](https://github.com/morkt/GARbro/blob/master/ArcFormats/KiriKiri/ImageTLG.cs) code.
 * All nuget references used in this project.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open and render Emote _pure_ PSB.
 ---
 by **Ulysses** (wdwxy12345@gmail.com) from Project AZUSA
 
-FreeMote is temporarily licensed under **LGPL**. Members from Project AZUSA can use it freely.
+FreeMote is licensed under **LGPL**.
 
 [Issue Report](https://github.com/UlyssesWu/FreeMote/issues) · [Pull Request](https://github.com/UlyssesWu/FreeMote/pulls) · [Wiki](https://github.com/Project-AZUSA/FreeMote/wiki)
 
@@ -48,5 +48,5 @@ FreeMote is temporarily licensed under **LGPL**. Members from Project AZUSA can 
 * Singyuen Yip for `Adler32` code.
 * @gdkchan for [DxtCodec](https://github.com/gdkchan/CEGTool/blob/master/CEGTool/DXTCodec.cs) code.
 * @mfascia for [TexturePacker](https://github.com/mfascia/TexturePacker) code.
-* @morkt for [ImageTLG](https://github.com/morkt/GARbro/blob/master/ArcFormats/KiriKiri/ImageTLG.cs) code.
+* @morkt for [ImageTLG](https://github.com/morkt/GARbro/blob/master/ArcFormats/KiriKiri/ImageTLG.cs) code. LICENSE: MIT
 * All nuget references used in this project.


### PR DESCRIPTION
# FreeMote 1.1

## Breaking change
`resx.json` is now different from `res.json`(psbfile format), and may still be changed to support more features.

## What's New

- Add support for `RGBA4444` pixel format.
- Add support for `ems` spec.
- Add support for `pimg`/`scn` PSB type.
- Add support for decoding `tlg` images (encoding is not implemented).
- New `resx.json` format. 
    - Support PSB version, spec and CryptKey setting in file.
    - When decompiling, some info such as PSB version is kept in `resx.json` so it won't be lost as before.
    - Before compiling, you can set `ExternalTextures` to `true` to skip resource compiling.
